### PR TITLE
fix: exit with error if cosign not installed instead of warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ This will start a container from the `capotej/harness` image, mount your current
 
 ### Image verification
 
-By default, harness verifies that the container image was signed by the official CI workflow and includes a valid SLSA provenance attestation. This requires [cosign](https://github.com/sigstore/cosign) (`brew install cosign`). If cosign is not installed, harness prints a warning and proceeds. To skip verification:
+By default, harness verifies that the container image was signed by the official CI workflow and includes a valid SLSA provenance attestation. This requires [cosign](https://github.com/sigstore/cosign) (`brew install cosign`). If cosign is not installed, harness exits with an error. Pass `--no-verify` to skip verification:
 
 ```bash
 npx @capotej/harness --no-verify -p "write me a fizzbuzz in Go"

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -261,9 +261,12 @@ async function verifyImage(image: string): Promise<void> {
     const e = verifyResult.reason as CosignError;
     if (e.code === "ENOENT") {
       console.error(
-        "harness: WARNING: cosign not found — skipping image verification (brew install cosign)",
+        "harness: cosign not found — cannot verify image without it.",
       );
-      return;
+      console.error(
+        "harness: install cosign (brew install cosign) or pass --no-verify to skip verification.",
+      );
+      process.exit(1);
     }
     console.error(
       `harness: image signature verification failed for ${digestRef}`,


### PR DESCRIPTION
## Summary

When `cosign` is not installed, harness currently prints a **warning** and proceeds to run the container. This PR changes that behavior to **exit with an error**, requiring the user to explicitly pass `--no-verify` to skip verification.

**Closes #6**

## Changes

- `src/harness.ts`: Changed ENOENT handler from `warning + return` to `error + process.exit(1)`
- `README.md`: Updated image verification section to reflect new behavior