### PR TITLE
Add PR build check workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,50 @@
+name: PR Build Check
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - name: Build base image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: localhost:5000/harness:base
+
+      - name: Build opencode variant
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.opencode
+          platforms: linux/amd64
+          push: true
+          build-args: BASE_IMAGE=localhost:5000/harness:base
+          tags: localhost:5000/harness:opencode
+
+      - name: Build hermes variant
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.hermes
+          platforms: linux/amd64
+          push: true
+          build-args: BASE_IMAGE=localhost:5000/harness:base
+          tags: localhost:5000/harness:hermes


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-build.yml` that triggers on every pull request
- Builds all three Docker images (base, opencode, hermes) for `linux/amd64` sequentially
- Uses an ephemeral local `registry:2` service — pushes go to `localhost:5000` only, never to ghcr.io
- No registry login or publish credentials required

## Test plan

- [ ] Open a PR and confirm the `PR Build Check` job runs and passes
- [ ] Confirm no images are published to ghcr.io as a result

🤖 Generated with [Claude Code](https://claude.com/claude-code)