### PR TITLE
docs: surface HARNESS_IMAGE_TAG in --help output

### DIFF
--- a/src/harness.ts
+++ b/src/harness.ts
@@ -313,6 +313,9 @@ Options:
   --ephemeral            Disable session persistence (implied by -p and piped stdin)
   -h, --help             Show this help message
 
+Environment variables:
+  HARNESS_IMAGE_TAG      Override the Docker image tag (defaults to package version)
+
 You can also pipe text to harness as an implied -p:
   echo "write me a fizzbuzz in Go" | harness
 `;


### PR DESCRIPTION
The README documents HARNESS_IMAGE_TAG but the CLI usage string didn't, so users running `harness --help` couldn't discover it. Mirror the README's "Environment variables" section in USAGE.