### PR TITLE
docs: add GH_TOKEN to fly.io setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ primary_region = "iad"
   TZ = "America/New_York"
 
 [build]
-  image = "ghcr.io/capotej/harness:hermes-1.4.3"
+  image = "ghcr.io/capotej/harness:hermes-1.4.4"
 
 [processes]
   app = "hermes gateway"

--- a/README.md
+++ b/README.md
@@ -211,8 +211,11 @@ fly secrets set OPENROUTER_API_KEY=<your-key> --app my-hermes-agent-claw
 # See https://hermes-agent.nousresearch.com/docs/user-guide/messaging/telegram#option-b-manual-configuration
 fly secrets set TELEGRAM_BOT_TOKEN=<your-token> --app my-hermes-agent-claw
 fly secrets set TELEGRAM_ALLOWED_USERS=<your-user-ids> --app my-hermes-agent-claw
+fly secrets set GH_TOKEN=<your-personal-access-token> --app my-hermes-agent-claw
 fly deploy --app my-hermes-agent-claw
 ```
+
+> **GitHub CLI access:** The `GH_TOKEN` secret makes the `gh` CLI available inside the container. Tell the agent to add `terminal.env_passthrough: [GH_TOKEN]` to its `config.yaml` so the token is accessible in the sandbox.
 
 ### Using your hermes-agent
 


### PR DESCRIPTION
## Summary
- Add `fly secrets set GH_TOKEN=<your-personal-access-token>` step to the fly.io deployment instructions
- Add a callout note explaining that the agent needs `terminal.env_passthrough: [GH_TOKEN]` in `config.yaml` so `gh` CLI works in the sandbox

## Test Plan
- [ ] README renders correctly