### PR TITLE
fix(pi): pass --provider ollama when -m is used without -e

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,37 @@ lms daemon up
 lms get google/gemma-4-e4b
 ```
 
-Then `cd` into any project and run:
+The container is preconfigured to use `gemma-4-e4b` via LM Studio's local API.
+
+You can also specify a different local model with `-m`. HuggingFace-style names with slashes (e.g. `qwen/qwen3.5-9b`) work correctly in local mode:
+
+```bash
+npx @capotej/harness -m "qwen/qwen3.5-9b" -p "write a fizzbuzz in Go"
+```
+
+### Using a cloud provider instead
+
+#### pi (default agent)
+
+If you pass an API key for a supported provider via `--env-file`, [`pi`](https://pi.dev/) will use that provider instead of the local LM Studio setup. Supported keys:
+
+| Provider | Environment Variable |
+|----------|----------------------|
+| Anthropic | `ANTHROPIC_API_KEY` |
+| OpenRouter | `OPENROUTER_API_KEY` |
+| OpenAI | `OPENAI_API_KEY` |
+| Google Gemini | `GEMINI_API_KEY` |
+| Mistral | `MISTRAL_API_KEY` |
+| Groq | `GROQ_API_KEY` |
+| Cerebras | `CEREBRAS_API_KEY` |
+| xAI | `XAI_API_KEY` |
+| Hugging Face | `HF_TOKEN` |
+
+See the [full list of supported providers](https://github.com/badlogic/pi-mono/blob/c779c14e91bc2ea65143e59b0dc1baf3646ba8c9/packages/coding-agent/docs/providers.md#api-keys) for more options. When using LM Studio locally, 16k context is sufficient.
+
+#### opencode agent
+
+[`opencode`](https://opencode.ai) uses LM Studio by default. To use OpenRouter instead, pass an env file containing `OPENROUTER_API_KEY`:
 
 ```bash
 npx @capotej/harness -p "write me a fizzbuzz in Go"

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -41,12 +41,18 @@ interface AgentAdapter {
 }
 
 class PiAdapter implements AgentAdapter {
-  buildCommand({ prompt, model }: AgentOptions): string[] {
+  buildCommand({ prompt, model, envFilePath }: AgentOptions): string[] {
+    // In local mode (no env file), pass --provider ollama so pi routes
+    // the model to the local LM Studio provider. Without this, model names
+    // containing slashes (e.g. HuggingFace IDs like "qwen/qwen3.5-9b") are
+    // misinterpreted as provider/model format, causing pi to silently ignore
+    // --model and fall back to a default that may require cloud credentials.
+    const providerArgs = !envFilePath && model ? ["--provider", "ollama"] : [];
     const modelArgs = model ? ["--model", model] : [];
     if (prompt !== null) {
-      return ["pi", "-p", prompt, ...modelArgs];
+      return ["pi", "-p", prompt, ...providerArgs, ...modelArgs];
     }
-    return ["pi", ...modelArgs];
+    return ["pi", ...providerArgs, ...modelArgs];
   }
 
   persistMounts(): PersistMount[] {

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -182,16 +182,20 @@ test("pi: prompt is forwarded as `pi -p <prompt>`", () => {
   assert.equal(tail[3], "pi"); // "pi" is second word of the prompt — split by space
 });
 
-test("pi: --model is forwarded as `pi --model <model>`", () => {
+test("pi: --model is forwarded with --provider ollama in local mode", () => {
   const r = runCli(["-p", "noop", "-m", "anthropic/claude-sonnet-4-5"]);
   assert.equal(r.status, 0, r.stderr);
   const a = dockerArgs(r.stdout);
   const idx = a.indexOf("pi");
   assert.notEqual(idx, -1);
-  assert.deepEqual(a.slice(idx, idx + 5), [
+  // In local mode (no env file), pi passes --provider ollama alongside --model
+  // so the model is routed to LM Studio even when the model name contains slashes.
+  assert.deepEqual(a.slice(idx, idx + 7), [
     "pi",
     "-p",
     "noop",
+    "--provider",
+    "ollama",
     "--model",
     "anthropic/claude-sonnet-4-5",
   ]);


### PR DESCRIPTION
When `-m` is used in local mode (no `-e` env file), model names containing slashes (e.g. HuggingFace IDs like `qwen/qwen3.5-9b`) were misinterpreted by pi as provider/model format. Since the prefix wasn't a known provider, pi silently ignored `--model` and fell back to default model selection, which could require cloud credentials not available in local mode.

Now passes `--provider ollama` alongside `--model` in local mode, ensuring pi routes the model to the local LM Studio provider and uses its buildFallbackModel mechanism for unknown model IDs.

Fixes #8