### PR TITLE
feat: add dpkg to passwordless sudoers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
     && apt-get purge -y --auto-remove gnupg \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m -s /bin/bash harness \
-    && echo 'harness ALL=(root) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt' > /etc/sudoers.d/harness \
+    && echo 'harness ALL=(root) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt, /usr/bin/dpkg' > /etc/sudoers.d/harness \
     && chmod 0440 /etc/sudoers.d/harness
 
 # Download, verify checksum, and install gh


### PR DESCRIPTION
## Problem

The harness user has passwordless sudo for `apt-get` and `apt` but not `dpkg`. If a package installation is interrupted (e.g. timeout, killed process), dpkg is left in a broken state and `dpkg --configure -a` is required to recover. Without sudo access to dpkg, the harness user cannot self-repair.

This specifically blocks `agent-browser install --with-deps` when the apt install times out mid-way, leaving the system in an unrecoverable state from within the container.

## Fix

Add `/usr/bin/dpkg` to the NOPASSWD sudoers rule:

```diff
-    && echo 'harness ALL=(root) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt' > /etc/sudoers.d/harness
+    && echo 'harness ALL=(root) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt, /usr/bin/dpkg' > /etc/sudoers.d/harness
```

## Impact

- Minimal security change — dpkg is already invoked indirectly through apt-get
- Enables self-recovery from interrupted package installs
- Required for tools like `agent-browser install --with-deps` that use sudo internally