### PR TITLE
chore: add tini as PID 1 for zombie reaping and signal forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN chmod +x /entrypoint.sh
 
 # Install tini (PID 1 zombie reaper + signal forwarder)
 # Checksums from: https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-{amd64,arm64}.sha256sum
-ENV TINI_VERSION v0.19.0
+ENV TINI_VERSION=v0.19.0
 ENV TINI_AMD64_SHA256=c5b0666b4cb676901f90dfcb37106783c5fe2077b04590973b885950611b30ee
 ENV TINI_ARM64_SHA256=eae1d3aa50c48fb23b8cbdf4e369d0910dfc538566bfd09df89a774aa84a48b9
 RUN set -eux && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,23 @@ COPY pi/models.json /etc/harness/pi-defaults/models.json
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Install tini (PID 1 zombie reaper + signal forwarder)
+# Checksums from: https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-{amd64,arm64}.sha256sum
+ENV TINI_VERSION v0.19.0
+ENV TINI_AMD64_SHA256=c5b0666b4cb676901f90dfcb37106783c5fe2077b04590973b885950611b30ee
+ENV TINI_ARM64_SHA256=eae1d3aa50c48fb23b8cbdf4e369d0910dfc538566bfd09df89a774aa84a48b9
+RUN set -eux && \
+    ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    case "${ARCH}" in \
+        amd64) TINI_ARCH=amd64; EXPECTED="${TINI_AMD64_SHA256}" ;; \
+        arm64) TINI_ARCH=arm64; EXPECTED="${TINI_ARM64_SHA256}" ;; \
+        *) echo "unsupported arch: ${ARCH}"; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-${TINI_ARCH}" \
+        -o /tini && \
+    echo "${EXPECTED}  /tini" | sha256sum --check --strict && \
+    chmod +x /tini
+
 USER harness
 WORKDIR /app
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -105,4 +105,4 @@ RUN chmod +x /entrypoint.sh
 
 USER harness
 WORKDIR /app
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -17,4 +17,4 @@ RUN chmod +x /entrypoint.sh
 
 USER harness
 WORKDIR /app
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]


### PR DESCRIPTION
## Summary

Add tini v0.19.0 as PID 1 to all harness container images to properly reap zombie processes and forward signals.

## The Problem

Currently hermes gateway (a Node.js process) runs as PID 1. Node.js does not call wait() on SIGCHLD by default, so child processes that exit become zombies. Over time zombies accumulate and can exhaust the container PID slots, eventually blocking new processes from spawning. This is especially problematic for a long-running messaging agent that constantly executes terminal() commands.

## The Fix

- Install tini in the base Dockerfile with SHA256-pinned checksums for amd64 + arm64
- Update all three ENTRYPOINTs (Dockerfile, Dockerfile.hermes, Dockerfile.opencode) to route through tini

## Security

- Binary checksums verified via sha256sum --check --strict at build time
- Pinned from official GitHub release checksums: tini-static-{amd64,arm64}.sha256sum
- Static binary (~20 KB), no dynamic linking, no runtime dependencies
- Same verification pattern already used for cosign, uv, and tirith in the Dockerfiles

## Resulting Process Tree

```
PID 1: tini
PID 2: hermes gateway  (or pi / opencode)
```

tini handles:
- Zombie reaping (wait() on all exited children)
- Proper signal forwarding (SIGTERM → hermes gateway)
- Graceful shutdown