### PR TITLE
test(pi): inverse case  env-file + -m omits --provider ollama

### DIFF
--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -207,7 +207,14 @@ test("pi: --model with --env-file does NOT inject --provider ollama (env mode)",
   // and the CLI must NOT override that with `--provider ollama`. This test
   // locks down the boundary so future refactors don't accidentally inject
   // --provider in env-file mode (or drop it in local mode).
-  const r = runCli(["-e", ENV_FILE, "-p", "noop", "-m", "anthropic/claude-sonnet-4-5"]);
+  const r = runCli([
+    "-e",
+    ENV_FILE,
+    "-p",
+    "noop",
+    "-m",
+    "anthropic/claude-sonnet-4-5",
+  ]);
   assert.equal(r.status, 0, r.stderr);
   const a = dockerArgs(r.stdout);
   const idx = a.indexOf("pi");

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -201,6 +201,34 @@ test("pi: --model is forwarded with --provider ollama in local mode", () => {
   ]);
 });
 
+test("pi: --model with --env-file does NOT inject --provider ollama (env mode)", () => {
+  // Inverse of the local-mode case above. When the user supplies --env-file,
+  // the provider/credentials are configured via env vars (e.g. OPENROUTER_API_KEY),
+  // and the CLI must NOT override that with `--provider ollama`. This test
+  // locks down the boundary so future refactors don't accidentally inject
+  // --provider in env-file mode (or drop it in local mode).
+  const r = runCli(["-e", ENV_FILE, "-p", "noop", "-m", "anthropic/claude-sonnet-4-5"]);
+  assert.equal(r.status, 0, r.stderr);
+  const a = dockerArgs(r.stdout);
+  const idx = a.indexOf("pi");
+  assert.notEqual(idx, -1);
+  // pi command tail is exactly: pi -p noop --model <model>
+  assert.deepEqual(a.slice(idx, idx + 5), [
+    "pi",
+    "-p",
+    "noop",
+    "--model",
+    "anthropic/claude-sonnet-4-5",
+  ]);
+  // And no --provider flag anywhere in pi's argv.
+  const tail = a.slice(idx);
+  assert.equal(
+    tail.indexOf("--provider"),
+    -1,
+    `unexpected --provider in env-file mode: ${tail.join(" ")}`,
+  );
+});
+
 // ---- opencode adapter ------------------------------------------------------
 
 test("opencode: image tag is `opencode-<version>`", () => {


### PR DESCRIPTION
# test(pi): inverse case — env-file + -m omits --provider ollama

## What

Adds a single e2e test that locks down the boundary added in #16:

> when `--env-file` is supplied, the CLI must NOT inject `--provider ollama`.

The positive case (local mode without `-e`, with `-m`) was already asserted in the test renamed in #16:

```
✔ pi: --model is forwarded with --provider ollama in local mode
```

This PR adds the negative case so future refactors of `PiAdapter.buildCommand` cannot silently flip the behaviour either way.

## Why

The current logic in `src/harness.ts`:

```ts
const providerArgs = !envFilePath && model ? ["--provider", "ollama"] : [];
```

is a one-liner where it would be very easy for a future change to drop the `!envFilePath &&` guard or invert it without anyone noticing — until users with custom env-file-configured providers see their provider getting overridden. The single-character difference between right and wrong here justifies an explicit assertion on each side.

## How verified

```
$ pnpm install --frozen-lockfile && pnpm build && pnpm test:e2e:cli
…
✔ pi: --model is forwarded with --provider ollama in local mode
✔ pi: --model with --env-file does NOT inject --provider ollama (env mode)
…
ℹ tests 20
ℹ pass  20
ℹ fail  0
```
