### PR TITLE
test(cli): assert HARNESS_IMAGE_TAG is documented in --help

### DIFF
--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -116,6 +116,20 @@ test("-h exits 0 and prints USAGE", () => {
   assert.match(r.stdout, /Usage: harness/);
 });
 
+test("--help documents HARNESS_IMAGE_TAG environment variable", () => {
+  // PR #13 added HARNESS_IMAGE_TAG to the help output. Lock that in so
+  // future changes to USAGE don't silently drop documented env vars.
+  const r = runCli(["--help"]);
+  assert.equal(r.status, 0, r.stderr);
+  // The env var name itself must appear.
+  assert.match(r.stdout, /HARNESS_IMAGE_TAG/);
+  // And it must be in the dedicated "Environment variables:" section
+  // so users can find it (not buried in prose).
+  assert.match(r.stdout, /Environment variables:[\s\S]*HARNESS_IMAGE_TAG/);
+  // And the description must explain what it does (override image tag).
+  assert.match(r.stdout, /HARNESS_IMAGE_TAG[\s\S]*[Dd]ocker image tag/);
+});
+
 test("unknown agent fails fast with helpful error", () => {
   const r = runCli(["-a", "bogus-agent", "-p", "noop"]);
   assert.notEqual(r.status, 0);


### PR DESCRIPTION
# test(cli): assert HARNESS_IMAGE_TAG is documented in --help

## What

Adds a single e2e test that locks in the documentation added in #13:

```
✔ --help documents HARNESS_IMAGE_TAG environment variable
```

The test asserts three things:

1. The string `HARNESS_IMAGE_TAG` appears in `--help` output.
2. It appears under the dedicated `Environment variables:` section (so users can find it).
3. Its description mentions overriding the Docker image tag.

## Why

Help-text regressions are easy to ship by accident — somebody refactors `USAGE`, drops a line, and the env var becomes invisible to new users. A 6-line test makes that a CI failure instead of a silent doc loss.

## How verified

```
$ pnpm install --frozen-lockfile && pnpm build && pnpm test:e2e:cli
…
✔ --help exits 0 and prints USAGE
✔ -h exits 0 and prints USAGE
✔ --help documents HARNESS_IMAGE_TAG environment variable
…
ℹ tests 20
ℹ pass  20
ℹ fail  0
```
