### PR TITLE
test(opencode): --env-file is forwarded for non-pi adapters too

### DIFF
--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -227,6 +227,21 @@ test("opencode: image tag is `opencode-<version>`", () => {
   );
 });
 
+test("opencode: --env-file is forwarded (env-file is adapter-agnostic)", () => {
+  // The existing --env-file test only exercises the pi adapter. --env-file
+  // is plumbed at the docker level (envFileArgs is built before the adapter
+  // is selected), so it MUST work for opencode too. Lock that contract.
+  const r = runCli(["-a", "opencode", "-e", ENV_FILE, "-p", "noop"]);
+  assert.equal(r.status, 0, r.stderr);
+  const a = dockerArgs(r.stdout);
+  const eIdx = a.indexOf("--env-file");
+  assert.notEqual(eIdx, -1, `--env-file missing in: ${a.join(" ")}`);
+  // Must be the absolute path (path.resolve in run()).
+  assert.equal(a[eIdx + 1], path.resolve(ENV_FILE));
+  // And opencode is still the agent.
+  assert.notEqual(a.indexOf("opencode"), -1);
+});
+
 test("opencode: --model is passed via OPENCODE_MODEL env, not CLI", () => {
   const r = runCli([
     "-a",


### PR DESCRIPTION
## What

Adds an e2e test that asserts `--env-file` is forwarded to docker as `--env-file <abs>` when the agent is **`opencode`** (not just the existing `pi` case).

## Why

`--env-file` is plumbed at the docker level (`envFileArgs` is built before the adapter is selected), so the contract is adapter-agnostic. The only existing `--env-file` test uses `pi`. A regression that special-cased the flag per adapter, or moved its construction into `PiAdapter.extraDockerArgs`, would slip through CI.

This test runs `harness -a opencode -e <file> -p noop` against the docker shim and asserts:
- `--env-file` is present in the docker argv
- The value is `path.resolve(ENV_FILE)` (matches `run()`'s behaviour)
- `opencode` is still the agent in the final argv

## How verified

```
pnpm install --frozen-lockfile && pnpm build && pnpm test:e2e:cli
# 21/21 pass (was 20/20)
pnpm lint:ts
# Checked 6 files. No fixes applied.
```

Net diff: `+1 test` in `tests/e2e/cli.test.mjs`.
