### PR TITLE
test(hermes): no -m and no -p emits exactly ['hermes','chat']

### DIFF
--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -258,6 +258,43 @@ test("opencode: --model is passed via OPENCODE_MODEL env, not CLI", () => {
 
 // ---- hermes adapter --------------------------------------------------------
 
+test("hermes: no -m, no -p emits exactly ['hermes','chat'] (no stray flags)", () => {
+  // Covers the no-model + interactive branch of HermesAdapter.buildCommand:
+  //   args = ["hermes","chat"]; no -m pushed (model falsy); no -q pushed
+  //   (prompt === null when no -p and no piped stdin).
+  // Locks that future refactors don't accidentally inject defaults for
+  // either flag in the no-args path.
+  //
+  // Requires a PTY so process.stdin.isTTY === true and the prompt stays null.
+  const which = spawnSync("sh", ["-c", "command -v script"], {
+    encoding: "utf8",
+  });
+  if (which.status !== 0) {
+    return;
+  }
+  const r = spawnSync(
+    "script",
+    ["-qfec", `node ${CLI} -a hermes`, "/dev/null"],
+    {
+      cwd: WORK_DIR,
+      env: {
+        ...process.env,
+        PATH: `${SHIM_DIR}:${process.env.PATH}`,
+        HARNESS_IMAGE_TAG: "test-tag",
+      },
+      encoding: "utf8",
+    },
+  );
+  assert.equal(r.status, 0, r.stderr);
+  const cleaned = r.stdout.replace(/\r/g, "");
+  const a = dockerArgs(cleaned);
+  assert.ok(a, `expected DOCKER_INVOKED line in: ${cleaned}`);
+  const idx = a.indexOf("hermes");
+  assert.notEqual(idx, -1);
+  // Exactly the two-token tail; no -m, no -q.
+  assert.deepEqual(a.slice(idx), ["hermes", "chat"]);
+});
+
 test("hermes: model is passed via -m <provider/model>", () => {
   const r = runCli([
     "-a",


### PR DESCRIPTION
## What

Adds an e2e test that locks down the **no-model + no-prompt** branch of `HermesAdapter.buildCommand`. Asserts the container argv tail is exactly:

```
["hermes", "chat"]
```

— with **no** `-m` (model is falsy) and **no** `-q` (prompt is `null`).

## Why

The existing hermes test (`hermes: model is passed via -m <provider/model>`) only covers the model + prompt branch. Nothing currently asserts the bare interactive case, so a future refactor that defaults `-m` to `openrouter/auto` or always appends a placeholder `-q` would slip through CI.

The branch is only reachable when `process.stdin.isTTY === true`. Test allocates a PTY via util-linux `script` (same pattern as the existing `pi: interactive ... no -p` test). Self-skips on platforms without `script`.

## How verified

```
pnpm install --frozen-lockfile && pnpm build && pnpm test:e2e:cli
# 21/21 pass (was 20/20)
pnpm lint:ts
# Checked 6 files. No fixes applied.
```

Net diff: `+1 test` in `tests/e2e/cli.test.mjs`.
