### PR TITLE
docs(readme): add 'Customizing the claw — don't extend the image' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,49 @@ fly deploy --app my-hermes-agent-claw
 
 Message the bot via Telegram, or wire it up to a scheduled workflow — see the [daily briefing bot guide](https://hermes-agent.nousresearch.com/docs/guides/daily-briefing-bot) for an example.
 
+### Customizing the claw — *don't* extend the image
+
+When you want to give the claw extra capabilities (tool wrappers around your APIs, an opinionated initial system prompt, custom `gh`-style scripts), the temptation is to write a `Dockerfile` that does `FROM ghcr.io/capotej/harness:hermes-1.5.0` and bakes everything in. **Don't.** Two problems:
+
+1. The fly volume mounts on top of `/home/harness/.hermes-openrouter`, which silently hides anything you `COPY` into that path on first boot.
+2. Hermes treats `config.yaml` as mutable state — TUI tweaks, model switches, and persona toggles are persisted via `save_config()`. A derived image fights that ownership.
+
+The supported pattern is to use the upstream image **unmodified** and inject your customizations via fly's [`[[files]]`](https://fly.io/docs/reference/configuration/#the-files-section) section. Files at non-volume paths get refreshed on every deploy; files seeded into `/etc/harness/hermes-defaults/openrouter/` get copied into the volume on first boot only (via `entrypoint-hermes.sh`'s `cp -rn`) so hermes' subsequent runtime config edits stick across restarts.
+
+Example — add a `crm` API wrapper script and an initial system prompt without building a new image:
+
+```toml
+# fly.toml — append to the example above
+
+# Tool wrappers — written to a non-volume path. Refreshed on every deploy.
+# fly [[files]] preserves the local file's exec bit, so your scripts run
+# as-is from the agent's sandbox.
+[[files]]
+  guest_path = "/etc/myclaw/bin/crm"
+  local_path = "bin/crm"
+
+# Initial config + persona. Upstream's hermes entrypoint copies these into
+# the volume on first boot only — after that, hermes owns its config.
+[[files]]
+  guest_path = "/etc/harness/hermes-defaults/openrouter/system-prompt.md"
+  local_path = "config/system-prompt.md"
+```
+
+To force a refresh of `config.yaml` or `system-prompt.md` from your repo after the first boot, SSH in and delete the volume's copy before redeploying:
+
+```bash
+fly ssh console --app my-hermes-agent-claw \
+  -C 'rm /home/harness/.hermes-openrouter/system-prompt.md'
+fly deploy --app my-hermes-agent-claw
+```
+
+The benefits over a derived image:
+
+- **Faster deploys** — no rebuild, just pull the upstream image and apply files. Seconds instead of minutes.
+- **Trivial upstream upgrades** — bump one tag in `fly.toml`.
+- **No fight with hermes** over `config.yaml` ownership.
+- **One fewer artifact** to maintain, sign, and verify.
+
 ## Developing
 
 Link your local checkout globally:


### PR DESCRIPTION
## Why

This is the constructive follow-up to #27 (closed).

The README's existing fly.io section explains how to *deploy* a claw, but doesn't say anything about how to *customize* one — give it tool wrappers around your APIs, an opinionated initial system prompt, etc. The natural next step a reader takes is to write a `Dockerfile` that does `FROM ghcr.io/capotej/harness:hermes-1.5.0` and bake their stuff in. That's exactly what I did, and it walked me head-first into two non-obvious failure modes:

1. **Volume mount shadowing** — fly mounts `nala_claw_data` on `/home/harness/.hermes-openrouter`, silently hiding anything `COPY`d to that path on first boot.
2. **`config.yaml` ownership** — hermes treats config as mutable runtime state via `save_config()`. A derived image fights that ownership and either wipes user TUI tweaks on every boot (#27's broken approach) or never reflects updated defaults (the original `cp -rn` approach for users who didn't realize they were extending the image).

Once @capotej pointed out that the right pattern is to use the upstream image **unmodified** and inject customizations via fly's `[[files]]`, the whole story collapsed to about 30 lines of fly.toml. But it took me ~3 hours of yak-shaving to get there because the README doesn't currently point readers at that pattern.

## What

New subsection inside the existing "Deploying hermes as a fly.io claw" section, titled **"Customizing the claw — *don't* extend the image"**. It:

- Names the two failure modes (so future readers can grep for them when they hit them).
- Shows a concrete `[[files]]` snippet for injecting both a tool wrapper at a non-volume path *and* an initial `system-prompt.md` via the existing `entrypoint-hermes.sh` seed step.
- Documents the "hermes owns `config.yaml` after first boot" semantic and how to force a refresh from the repo (SSH in, `rm`, redeploy).
- Closes with a quick benefits list (faster deploys, trivial upstream bumps, no config fight).

No code changes. `markdownlint` clean.

## Demo

After applying this pattern to my own Nala Claw deployment:

- Deploy time: **~5 min → ~6 sec** (no rebuild, just pull upstream + apply files)
- Maintenance surface: **−39 lines of Dockerfile + −5 lines of .dockerignore + −41 lines of seed-and-run wrapper script** that we no longer need
- Hermes now correctly owns `config.yaml`; TUI tweaks survive restarts

## Validation

Existing `markdownlint-cli2` passes:

```
$ npx markdownlint-cli2 "README.md"
markdownlint-cli2 v0.17.2 (markdownlint v0.37.4)
Finding: README.md !node_modules/ !CHANGELOG.md !.claude/
Linting: 1 file(s)
Summary: 0 error(s)
```
