### PR TITLE
test(cli): --ephemeral overrides interactive PTY (no .harness/, no persist mount)

### DIFF
--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -505,3 +505,51 @@ test("interactive (PTY, no -p, no --ephemeral) creates .harness/<agent>/ persist
     `expected a -v mount ending in :${mountTarget} in: ${a.join(" ")}`,
   );
 });
+
+test("--ephemeral overrides interactive PTY: no .harness/ dir, no persist mount", () => {
+  // Inverse of the interactive-PTY persistence test: when the user is in a
+  // real PTY (TTY, no -p, no piped stdin) but EXPLICITLY passes --ephemeral,
+  // the run() path must NOT create .harness/<agent>/ and must NOT include
+  // the adapter's persistMounts() in the docker args.
+  //
+  // This locks the precedence of the --ephemeral flag in
+  // `effectiveEphemeral = argv.ephemeral || promptArg !== null || !process.stdin.isTTY`
+  // so a future refactor can't accidentally drop the OR-with-argv.ephemeral
+  // and re-introduce host-side directories for opt-out users.
+  const which = spawnSync("sh", ["-c", "command -v script"], {
+    encoding: "utf8",
+  });
+  if (which.status !== 0) {
+    return; // platforms without `script` (rare; ubuntu-latest has it).
+  }
+  const localWork = fs.mkdtempSync(path.join(os.tmpdir(), "harness-e2e-cwd-"));
+  const r = spawnSync(
+    "script",
+    ["-qfec", `node ${CLI} --ephemeral`, "/dev/null"],
+    {
+      cwd: localWork,
+      env: {
+        ...process.env,
+        PATH: `${SHIM_DIR}:${process.env.PATH}`,
+        HARNESS_IMAGE_TAG: "test-tag",
+      },
+      encoding: "utf8",
+    },
+  );
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(
+    fs.existsSync(path.join(localWork, ".harness")),
+    false,
+    ".harness/ must NOT be created when --ephemeral is passed in interactive mode",
+  );
+  const cleaned = r.stdout.replace(/\r/g, "");
+  const a = dockerArgs(cleaned);
+  assert.ok(a, `expected DOCKER_INVOKED line in: ${cleaned}`);
+  const mountTarget = "/home/harness/.pi/agent";
+  const hasMount = a.some((arg) => arg.endsWith(`:${mountTarget}`));
+  assert.equal(
+    hasMount,
+    false,
+    `--ephemeral must suppress persistMounts(); got mount in: ${a.join(" ")}`,
+  );
+});


### PR DESCRIPTION
## Summary

Locks the precedence of the `--ephemeral` flag in `effectiveEphemeral` (`src/harness.ts`):

```ts
const effectiveEphemeral =
  argv.ephemeral || promptArg !== null || !process.stdin.isTTY;
```

The existing test at line 462 (`interactive (PTY, no -p, no --ephemeral) creates .harness/<agent>/ persistence dir`) covers the **default** interactive path. This new test covers the **inverse**: when the user is in a real PTY but explicitly passes `--ephemeral`, the run path must NOT create `.harness/` and must NOT include the adapter's `persistMounts()` in the docker args.

## Why

A future refactor could accidentally drop the `argv.ephemeral ||` term (e.g. by inverting the boolean or replacing the OR with `&&`). The current suite would still pass — both `-p` and piped-stdin paths exercise the other two terms — but opt-out users would silently start getting host-side `.harness/` directories created against their explicit wishes.

## How verified

- Allocates a real PTY via `script -qfec` (same pattern as the existing interactive test).
- Asserts exit 0, no `.harness/` directory exists, and no docker `-v` mount targets `/home/harness/.pi/agent`.
- Skips on platforms without `script` (matches existing test convention).
- Local: `pnpm run test:e2e:cli` → 25/25 pass.
- Lint: `pnpm run lint:ts` clean.