### PR TITLE
test(opencode): interactive run materializes all 3 persistence dirs and mounts

### DIFF
--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -607,7 +607,6 @@ test("--ephemeral overrides interactive PTY: no .harness/ dir, no persist mount"
     `--ephemeral must suppress persistMounts(); got mount in: ${a.join(" ")}`,
   );
 });
-
 test("piped whitespace-only stdin takes no-prompt branch (pi has no -p)", () => {
   // The stdin handler at the bottom of run() is:
   //   run(input.trim() ? input : null)
@@ -649,4 +648,62 @@ test("piped whitespace-only stdin takes no-prompt branch (pi has no -p)", () => 
     false,
     `whitespace stdin must NOT inject -p; got cmd: ${tail.join(" ")}`,
   );
+});
+
+test("opencode interactive (no --ephemeral) creates all three persistence dirs and mounts", () => {
+  // OpenCodeAdapter.persistMounts() returns three distinct mounts:
+  //   - config -> /home/harness/.config/opencode
+  //   - share  -> /home/harness/.local/share/opencode
+  //   - state  -> /home/harness/.local/state/opencode
+  //
+  // The pi adapter test only locks a single empty-hostSubpath mount. This
+  // test locks the multi-mount shape so a future refactor can't silently
+  // drop one of the three OpenCode persistence buckets (which would lose
+  // user history / config across container runs).
+  const which = spawnSync("sh", ["-c", "command -v script"], {
+    encoding: "utf8",
+  });
+  if (which.status !== 0) {
+    return; // skip on platforms without `script`.
+  }
+  const localWork = fs.mkdtempSync(path.join(os.tmpdir(), "harness-e2e-cwd-"));
+  const r = spawnSync(
+    "script",
+    ["-qfec", `node ${CLI} -a opencode`, "/dev/null"],
+    {
+      cwd: localWork,
+      env: {
+        ...process.env,
+        PATH: `${SHIM_DIR}:${process.env.PATH}`,
+        HARNESS_IMAGE_TAG: "test-tag",
+      },
+      encoding: "utf8",
+    },
+  );
+  assert.equal(r.status, 0, r.stderr);
+
+  // All three host-side persistence buckets must be created.
+  for (const sub of ["config", "share", "state"]) {
+    assert.equal(
+      fs.existsSync(path.join(localWork, ".harness", "opencode", sub)),
+      true,
+      `.harness/opencode/${sub}/ should be created in interactive mode`,
+    );
+  }
+
+  // All three docker -v mounts must target the documented container paths.
+  const cleaned = r.stdout.replace(/\r/g, "");
+  const a = dockerArgs(cleaned);
+  assert.ok(a, `expected DOCKER_INVOKED line in: ${cleaned}`);
+  const targets = [
+    "/home/harness/.config/opencode",
+    "/home/harness/.local/share/opencode",
+    "/home/harness/.local/state/opencode",
+  ];
+  for (const t of targets) {
+    assert.ok(
+      a.some((arg) => arg.endsWith(`:${t}`)),
+      `expected -v mount ending in :${t} in: ${a.join(" ")}`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

Locks the multi-mount shape of `OpenCodeAdapter.persistMounts()` in `src/harness.ts`:

```ts
persistMounts(): PersistMount[] {
  return [
    { hostSubpath: "config", containerPath: "/home/harness/.config/opencode" },
    { hostSubpath: "share",  containerPath: "/home/harness/.local/share/opencode" },
    { hostSubpath: "state",  containerPath: "/home/harness/.local/state/opencode" },
  ];
}
```

The pi adapter test at line 462 only locks a single empty-`hostSubpath` mount. Nothing in the current suite asserts that **all three** OpenCode persistence buckets are materialized on disk and forwarded to docker. A future refactor could silently drop one (e.g. consolidate `share` + `state`) and quietly lose user history or config across container runs without breaking any test.

## Why

OpenCode persists user-visible state across runs in three filesystem locations. Each one matters for a different concern (config = settings, share = data/history, state = transient app state). A lost mount = a silent regression nobody catches until a user complains.

## How verified

- Allocates a real PTY via `script -qfec` (same pattern as existing interactive test).
- Asserts:
  - exit 0
  - all 3 host-side dirs (`.harness/opencode/{config,share,state}`) are created
  - all 3 docker `-v` mounts target the documented container paths
- Skips on platforms without `script`.
- Local: `pnpm run test:e2e:cli` → 25/25 pass.
- Lint: `pnpm run lint:ts` clean.