### PR TITLE
fix: npm warns about unknown config minimumReleaseAge

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-minimumReleaseAge=10080

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,7 @@ RUN corepack enable && corepack prepare pnpm@10.33.2 --activate && \
     mkdir -p /etc/harness/pi-defaults && \
     chown -R harness:harness /usr/local/share/pnpm
 
-COPY .npmrc /etc/harness/.npmrc
-ENV NPM_CONFIG_GLOBALCONFIG=/etc/harness/.npmrc
+ENV PNPM_MINIMUM_RELEASE_AGE=10080
 
 COPY pi/models.json /etc/harness/pi-defaults/models.json
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ npx @capotej/harness --no-verify -p "write me a fizzbuzz in Go"
 
 When an agent runs `pnpm install` or `uv pip install` inside the container, any package published in the last 7 days is rejected — a guard against supply-chain compromises that are typically discovered and yanked within hours.
 
-- **pnpm**: `minimumReleaseAge=10080` (minutes) via `.npmrc`
+- **pnpm**: `PNPM_MINIMUM_RELEASE_AGE=10080` (minutes) via environment variable
 - **uv**: `--exclude-newer` set to 7 days ago at image build time
 
 The cooldown applies to transitive dependencies too. Older packages install normally.


### PR DESCRIPTION
Closes #33

## Problem

`minimumReleaseAge` is a pnpm-specific `.npmrc` setting that was stored in `.npmrc` and applied globally via `NPM_CONFIG_GLOBALCONFIG=/etc/harness/.npmrc`. Since npm also reads this file when that env var is set, it emits a warning:

> Unknown project config 'minimumReleaseAge'. This will stop working in the next major version of npm.

## Fix

Replace the `.npmrc` + `NPM_CONFIG_GLOBALCONFIG` approach with the pnpm-specific environment variable `PNPM_MINIMUM_RELEASE_AGE=10080`. pnpm reads `PNPM_`-prefixed env vars for all its settings, while npm ignores them — so the cooldown enforcement continues to work for pnpm but no longer triggers npm warnings.

### Changes

- **Delete `.npmrc`** — no longer needed
- **Dockerfile**: Replace `COPY .npmrc` + `ENV NPM_CONFIG_GLOBALCONFIG` with `ENV PNPM_MINIMUM_RELEASE_AGE=10080`
- **README.md / CLAUDE.md**: Update dependency cooldown documentation