### PR TITLE
fix: resolve markdownlint errors in .agents/skills

### DIFF
--- a/.agents/skills/analyze-image/SKILL.md
+++ b/.agents/skills/analyze-image/SKILL.md
@@ -6,6 +6,7 @@ description: Analyze the harness Docker image size — layer-by-layer breakdown,
 # Analyze Image Size
 
 Produces a three-part breakdown of the harness Docker image:
+
 1. All available tags and their sizes
 2. Per-layer contribution (from `docker history`)
 3. Efficiency and waste report (from `dive --ci`)
@@ -53,6 +54,7 @@ docker run --rm \
 ```
 
 This outputs:
+
 - Overall efficiency percentage
 - Total wasted bytes
 - A ranked list of inefficient files (files duplicated across layers)
@@ -61,7 +63,7 @@ This outputs:
 
 Present the results as a unified report:
 
-```
+```text
 ## Image size analysis: <image>
 
 ### Tags

--- a/.agents/skills/check-deps/SKILL.md
+++ b/.agents/skills/check-deps/SKILL.md
@@ -44,6 +44,7 @@ This project pins eight external dependencies across its Dockerfiles. Check each
 3. **Parse GitHub release output** — `gh release list` returns columns: Title / Type / Tag / Published. The tag is in column 3. Strip leading `v` for semver comparison. Skip tags containing `-rc`, `-alpha`, `-beta`, or `-pre` unless all releases are pre-releases.
 
    **hermes-agent cooldown check**: hermes tags follow `vYYYY.M.DD` (e.g. `v2026.4.23` = April 23 2026). Parse the date from the tag and compute days since release:
+
    ```bash
    python3 -c "
    from datetime import date
@@ -53,11 +54,12 @@ This project pins eight external dependencies across its Dockerfiles. Check each
    print((date.today() - release).days)
    "
    ```
+
    If the latest release is **fewer than 7 days old**, mark it as `on cooldown 🕐` and do **not** recommend upgrading, even if it is newer than the pinned version.
 
 4. **Compare and report** — produce a clean table:
 
-```
+```text
 | Dependency                    | Pinned       | Latest       | Status          |
 |-------------------------------|--------------|--------------|-----------------|
 | @mariozechner/pi-coding-agent | 0.67.68      | 0.70.1       | outdated ⬆      |
@@ -70,7 +72,7 @@ This project pins eight external dependencies across its Dockerfiles. Check each
 | debian:stable-slim            | sha256:e51b… | sha256:e51b… | up to date      |
 ```
 
-5. **For each outdated dep, show the exact edit needed** — file path, the current line, and what it should change to. Be specific so the user can apply the update immediately or ask you to do it.
+1. **For each outdated dep, show the exact edit needed** — file path, the current line, and what it should change to. Be specific so the user can apply the update immediately or ask you to do it.
 
 ## Notes on specific deps
 

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -54,6 +54,7 @@ Collect these as bullet points for the changelog: `- <short-hash> <message>`
 ## Step 4: Update CHANGELOG.md
 
 Get today's date:
+
 ```bash
 date +%Y-%m-%d
 ```
@@ -63,6 +64,7 @@ Based on the commits collected, write a 1–3 sentence prose summary of what cha
 **Dockerfile dependency changes** — Diff `Dockerfile`, `Dockerfile.opencode`, and `Dockerfile.hermes` against the last tag to find any version bumps to installed tools (e.g. `@mariozechner/pi-coding-agent`, `opencode-ai`, `hermes-agent`, `uv`, `pnpm`, `debian`, etc.). If any are found, include a `### Dependency Updates` section listing each change as `- updated <package> from <old> to <new>`.
 
 **Upstream release notes for pi, opencode, and hermes-agent** — If any of these three were bumped, fetch the release notes for every version between the old pin (exclusive) and the new pin (inclusive) and include them in a `### Upstream Release Notes` section. Run the fetches in parallel:
+
 - `@mariozechner/pi-coding-agent`: use `npm show @mariozechner/pi-coding-agent versions --json` to enumerate intermediate versions, then `gh release view <tag> --repo badlogic/pi-mono --json tagName,body` for each (tags match npm versions with a `v` prefix, e.g. `v0.70.2`)
 - `opencode-ai`: `gh release view <tag> --repo sst/opencode --json tagName,body` for each version between old and new (tags are prefixed with `v`)
 - `hermes-agent`: `gh release view <tag> --repo NousResearch/hermes-agent --json tagName,body` for each tag between old and new
@@ -91,6 +93,7 @@ Summarize each release in 2–4 bullet points (new features, breaking changes, n
 Omit `### Dependency Updates` and `### Upstream Release Notes` entirely if there are no relevant changes.
 
 **If CHANGELOG.md does not exist**, create it:
+
 ```markdown
 # Changelog
 
@@ -121,8 +124,9 @@ Edit the `version` field directly in `package.json`. Do not use `npm version` �
 
 The fly.toml example in `README.md` contains a pinned hermes image tag (e.g. `ghcr.io/capotej/harness:hermes-1.4.4`). Update it to the new version:
 
-```
+```toml
 image = "ghcr.io/capotej/harness:hermes-<new-version>"
+
 ```
 
 Search for the pattern `hermes-[0-9]` in `README.md` and replace all occurrences with the new version.
@@ -198,6 +202,7 @@ gh run view <run-id> --repo <owner>/<repo>
 ```
 
 Check that **all jobs** show `✓` (success). Pay particular attention to:
+
 - `build-variant (hermes, ...)` — most likely to fail due to the uv attestation verification step
 - `merge-variant (hermes)` and `merge-variant (opencode)` — these push the versioned image tags
 
@@ -214,6 +219,7 @@ Only report the release as complete once the entire workflow is green.
 ## Final report
 
 Tell the user:
+
 - Version released
 - The CHANGELOG entry added
 - GitHub release URL (from `gh release create` stdout)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ The image tag is selected at runtime based on `--agent`: pi uses `<version>`, ot
 **Persistence:** Interactive runs (no `-p`, no piped stdin, no `--ephemeral`) bind-mount `.harness/<agent>/` from the working directory into the container. Each adapter declares its own mount points via `persistMounts()`. One-shot runs are implicitly ephemeral.
 
 **Entrypoints:** Each variant has its own entrypoint that seeds default configs into the agent's home directory and detects the provider from env vars:
+
 - `entrypoint.sh` (pi) — seeds pi defaults from `/etc/harness/pi-defaults`
 - `entrypoint-opencode.sh` — detects `OPENROUTER_API_KEY` to switch between LM Studio and OpenRouter configs; sets `OPENCODE_MODEL` env var
 - `entrypoint-hermes.sh` — seeds hermes defaults from `/etc/harness/hermes-defaults/{local,openrouter}`; sets `HERMES_HOME` based on provider


### PR DESCRIPTION
## Summary

Fixes all 14 markdownlint errors in the  directory and  introduced by the "de-CLAUDE.md" commit.

## Changes

- **** (3 fixes): Added blank lines before lists (MD032), added  language to fenced code block (MD040)
- **** (5 fixes): Added blank lines around fenced code blocks (MD031), added  language to fenced code block (MD040), fixed ordered list prefix restart (MD029)
- **** (5 fixes): Added blank lines before lists and around fenced code blocks (MD031, MD032), added  language to fenced code block (MD040)
- **** (1 fix): Added blank line before list (MD032)

## Verification

```
markdownlint-cli2 .agents/skills/ AGENTS.md
Summary: 0 error(s)
```