### PR TITLE
feat: mount user skills directories into container, add --no-skills flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,13 @@ The image tag is selected at runtime based on `--agent`: pi uses `<version>`, ot
 
 **Persistence:** Interactive runs (no `-p`, no piped stdin, no `--ephemeral`) bind-mount `.harness/<agent>/` from the working directory into the container. Each adapter declares its own mount points via `persistMounts()`. One-shot runs are implicitly ephemeral.
 
+**User skills:** By default, harness bind-mounts the host user's skills directories into the container so agents can discover and use custom skills. Two source directories are checked (only if they exist on the host):
+
+- `~/.agents/skills` → `/home/harness/.agents/skills`
+- `~/.claude/skills` → `/home/harness/.claude/skills`
+
+Skills mounting applies to all run modes (interactive, one-shot, `--file`). Non-existent directories are silently skipped. Disable with `--no-skills`.
+
 **Entrypoints:** Each variant has its own entrypoint that seeds default configs into the agent's home directory and detects the provider from env vars:
 
 - `entrypoint.sh` (pi) — seeds pi defaults from `/etc/harness/pi-defaults`
@@ -82,6 +89,7 @@ E2E tests in `tests/e2e/cli.test.mjs` use a docker shim (a fake `docker` binary 
 - Volume mount construction (file vs directory, adapter-specific mount points)
 - `--env-file` forwarding across all adapters
 - `--model` handling (local vs env-file mode, `--provider ollama` injection)
+- User skills mounting (`~/.agents/skills`, `~/.claude/skills`, `--no-skills` flag)
 
 Run with: `pnpm test:e2e` (requires `pnpm build` first).
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ npx @capotej/harness --no-verify -p "write me a fizzbuzz in Go"
 
 ### Dependency cooldown
 
-When an agent runs `pnpm install` or `uv pip install` inside the container, any package published in the last 7 days is rejected — a guard against supply-chain compromises that are typically discovered and yanked within hours.
+The image build enforces a 7-day cooldown on dependency resolution — a guard against supply-chain compromises that are typically discovered and yanked within hours.
 
 - **pnpm**: `PNPM_MINIMUM_RELEASE_AGE=10080` (minutes) via environment variable
 - **uv**: `--exclude-newer` set to 7 days ago at image build time

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and [`hermes`](https://github.com/NousResearch/hermes-agent) — so you can poin
 - **Supply-chain hardened** — the image is signed and verified with cosign and SLSA provenance on every run; dependencies installed inside the container are always pinned and verified where possible and a 7-day "cooldown" is used to mitigate supply-chain attacks.
 - **Local-first** — defaults to LM Studio with `gemma-4-e4b`. Drop in an `--env-file` to use Anthropic, OpenRouter, OpenAI, Gemini, and others.
 - **Stateful or one-shot** — interactive runs persist agent state under `.harness/<agent>/`; one-shot prompts (`-p` or piped stdin) stay ephemeral.
+- **User skills** — automatically mounts `~/.agents/skills` and `~/.claude/skills` into the container so agents can discover and use custom skills. Disable with `--no-skills`.
 - **Zero install** — `npx @capotej/harness` just works.
 
 ## Quickstart
@@ -219,6 +220,7 @@ Add `.harness/` to your `.gitignore`.
 | `--model`     | `-m`  | Override the model used by the agent |
 | `--agent`     | `-a`  | Select agent: `pi`, `opencode`, `hermes` (default: `pi`) |
 | `--no-verify` |       | Skip cosign signature and provenance verification |
+| `--no-skills` |       | Disable mounting user skills directories (`~/.agents/skills`, `~/.claude/skills`) |
 | `--ephemeral` |       | Disable session persistence (implied by `-p` and piped stdin) |
 | `--help`      | `-h`  | Show help |
 

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -447,8 +447,14 @@ async function run(prompt: string | null): Promise<void> {
 
   if (!noSkills) {
     const skillDirs = [
-      { host: path.resolve(os.homedir(), ".agents", "skills"), container: "/home/harness/.agents/skills" },
-      { host: path.resolve(os.homedir(), ".claude", "skills"), container: "/home/harness/.claude/skills" },
+      {
+        host: path.resolve(os.homedir(), ".agents", "skills"),
+        container: "/home/harness/.agents/skills",
+      },
+      {
+        host: path.resolve(os.homedir(), ".claude", "skills"),
+        container: "/home/harness/.claude/skills",
+      },
     ];
     for (const sd of skillDirs) {
       if (fs.existsSync(sd.host) && fs.statSync(sd.host).isDirectory()) {

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -21,6 +21,7 @@ interface Args extends ParsedArgs {
   m?: string;
   agent?: string;
   a?: string;
+  skills?: boolean;
 }
 
 interface AgentOptions {
@@ -316,6 +317,7 @@ Options:
   -m, --model <model>    Override the model used by the agent
   -a, --agent <name>     Select the coding agent adapter: pi, opencode, hermes (default: pi)
   --no-verify            Skip cosign image signature and provenance verification
+  --no-skills            Disable mounting user skills directories (~/.agents/skills, ~/.claude/skills)
   --ephemeral            Disable session persistence (implied by -p and piped stdin)
   -h, --help             Show this help message
 
@@ -366,6 +368,7 @@ if (argv.help) {
 }
 
 const noVerify = argv["no-verify"];
+const noSkills = argv.skills === false;
 const envFilePath = argv["env-file"] || null;
 const fileArg = argv.file || null;
 const promptArg = argv.prompt || null;
@@ -438,6 +441,18 @@ async function run(prompt: string | null): Promise<void> {
         const hostFullPath = path.join(persistRoot, mount.hostSubpath);
         fs.mkdirSync(hostFullPath, { recursive: true });
         volumeArgs.push("-v", `${hostFullPath}:${mount.containerPath}`);
+      }
+    }
+  }
+
+  if (!noSkills) {
+    const skillDirs = [
+      { host: path.join(os.homedir(), ".agents", "skills"), container: "/home/harness/.agents/skills" },
+      { host: path.join(os.homedir(), ".claude", "skills"), container: "/home/harness/.claude/skills" },
+    ];
+    for (const sd of skillDirs) {
+      if (fs.existsSync(sd.host)) {
+        volumeArgs.push("-v", `${sd.host}:${sd.container}`);
       }
     }
   }

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -339,7 +339,7 @@ function getImage(agent: string): string {
 }
 
 const argv = minimist<Args>(process.argv.slice(2), {
-  boolean: ["help", "h", "no-verify", "ephemeral", "skills"],
+  boolean: ["help", "h", "no-verify", "ephemeral"],
   string: [
     "env-file",
     "e",

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -21,6 +21,7 @@ interface Args extends ParsedArgs {
   m?: string;
   agent?: string;
   a?: string;
+  // minimist --no- prefix: --no-skills sets this to false; NOT in boolean[] to avoid double-negation
   skills?: boolean;
 }
 

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -339,7 +339,7 @@ function getImage(agent: string): string {
 }
 
 const argv = minimist<Args>(process.argv.slice(2), {
-  boolean: ["help", "h", "no-verify", "ephemeral"],
+  boolean: ["help", "h", "no-verify", "ephemeral", "skills"],
   string: [
     "env-file",
     "e",
@@ -447,11 +447,11 @@ async function run(prompt: string | null): Promise<void> {
 
   if (!noSkills) {
     const skillDirs = [
-      { host: path.join(os.homedir(), ".agents", "skills"), container: "/home/harness/.agents/skills" },
-      { host: path.join(os.homedir(), ".claude", "skills"), container: "/home/harness/.claude/skills" },
+      { host: path.resolve(os.homedir(), ".agents", "skills"), container: "/home/harness/.agents/skills" },
+      { host: path.resolve(os.homedir(), ".claude", "skills"), container: "/home/harness/.claude/skills" },
     ];
     for (const sd of skillDirs) {
-      if (fs.existsSync(sd.host)) {
+      if (fs.existsSync(sd.host) && fs.statSync(sd.host).isDirectory()) {
         volumeArgs.push("-v", `${sd.host}:${sd.container}`);
       }
     }

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -9,8 +9,10 @@ import minimist, { type ParsedArgs } from "minimist";
 interface Args extends ParsedArgs {
   help: boolean;
   h: boolean;
-  "no-verify": boolean;
+  // minimist --no- prefix: --no-verify / --no-skills set these to false; NOT in boolean[] to avoid double-negation
+  verify?: boolean;
   ephemeral: boolean;
+  skills?: boolean;
   "env-file"?: string;
   e?: string;
   file?: string;
@@ -21,8 +23,6 @@ interface Args extends ParsedArgs {
   m?: string;
   agent?: string;
   a?: string;
-  // minimist --no- prefix: --no-skills sets this to false; NOT in boolean[] to avoid double-negation
-  skills?: boolean;
 }
 
 interface AgentOptions {
@@ -340,7 +340,7 @@ function getImage(agent: string): string {
 }
 
 const argv = minimist<Args>(process.argv.slice(2), {
-  boolean: ["help", "h", "no-verify", "ephemeral"],
+  boolean: ["help", "h", "ephemeral"],
   string: [
     "env-file",
     "e",
@@ -368,7 +368,7 @@ if (argv.help) {
   process.exit(0);
 }
 
-const noVerify = argv["no-verify"];
+const noVerify = argv.verify === false;
 const noSkills = argv.skills === false;
 const envFilePath = argv["env-file"] || null;
 const fileArg = argv.file || null;

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -709,14 +709,22 @@ test("opencode interactive (no --ephemeral) creates all three persistence dirs a
 });
 
 // ---- user skills mounting --------------------------------------------------
+//
+// All skills tests use a temp directory as HOME via extraEnv so the CLI's
+// os.homedir() resolves there.  This avoids creating/removing dirs in the
+// caller's real home directory and eliminates the risk of leaving artifacts
+// behind on test failure.
+
+function makeSkillsHome() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "harness-skills-"));
+  return { home: tmp, cleanup: () => fs.rmSync(tmp, { recursive: true, force: true }) };
+}
 
 test("existing ~/.agents/skills is mounted into the container", () => {
-  const agentsSkills = path.join(os.homedir(), ".agents", "skills");
-  // Create the directory if it doesn't exist so the test is deterministic.
-  const created = !fs.existsSync(agentsSkills);
-  if (created) fs.mkdirSync(agentsSkills, { recursive: true });
+  const { home, cleanup } = makeSkillsHome();
+  fs.mkdirSync(path.join(home, ".agents", "skills"), { recursive: true });
   try {
-    const r = runCli(["-p", "noop"]);
+    const r = runCli(["-p", "noop"], { extraEnv: { HOME: home } });
     assert.equal(r.status, 0, r.stderr);
     const a = dockerArgs(r.stdout);
     assert.ok(a, "expected DOCKER_INVOKED line");
@@ -725,16 +733,15 @@ test("existing ~/.agents/skills is mounted into the container", () => {
       `expected .agents/skills mount in: ${a.join(" ")}`,
     );
   } finally {
-    if (created) fs.rmSync(agentsSkills, { recursive: true, force: true });
+    cleanup();
   }
 });
 
 test("existing ~/.claude/skills is mounted into the container", () => {
-  const claudeSkills = path.join(os.homedir(), ".claude", "skills");
-  const created = !fs.existsSync(claudeSkills);
-  if (created) fs.mkdirSync(claudeSkills, { recursive: true });
+  const { home, cleanup } = makeSkillsHome();
+  fs.mkdirSync(path.join(home, ".claude", "skills"), { recursive: true });
   try {
-    const r = runCli(["-p", "noop"]);
+    const r = runCli(["-p", "noop"], { extraEnv: { HOME: home } });
     assert.equal(r.status, 0, r.stderr);
     const a = dockerArgs(r.stdout);
     assert.ok(a, "expected DOCKER_INVOKED line");
@@ -743,19 +750,16 @@ test("existing ~/.claude/skills is mounted into the container", () => {
       `expected .claude/skills mount in: ${a.join(" ")}`,
     );
   } finally {
-    if (created) fs.rmSync(claudeSkills, { recursive: true, force: true });
+    cleanup();
   }
 });
 
 test("--no-skills suppresses all skills mounts", () => {
-  const agentsSkills = path.join(os.homedir(), ".agents", "skills");
-  const claudeSkills = path.join(os.homedir(), ".claude", "skills");
-  const createdAgents = !fs.existsSync(agentsSkills);
-  const createdClaude = !fs.existsSync(claudeSkills);
-  if (createdAgents) fs.mkdirSync(agentsSkills, { recursive: true });
-  if (createdClaude) fs.mkdirSync(claudeSkills, { recursive: true });
+  const { home, cleanup } = makeSkillsHome();
+  fs.mkdirSync(path.join(home, ".agents", "skills"), { recursive: true });
+  fs.mkdirSync(path.join(home, ".claude", "skills"), { recursive: true });
   try {
-    const r = runCli(["--no-skills", "-p", "noop"]);
+    const r = runCli(["--no-skills", "-p", "noop"], { extraEnv: { HOME: home } });
     assert.equal(r.status, 0, r.stderr);
     const a = dockerArgs(r.stdout);
     assert.ok(a, "expected DOCKER_INVOKED line");
@@ -770,21 +774,15 @@ test("--no-skills suppresses all skills mounts", () => {
       `--no-skills must not mount .claude/skills: ${a.join(" ")}`,
     );
   } finally {
-    if (createdAgents) fs.rmSync(agentsSkills, { recursive: true, force: true });
-    if (createdClaude) fs.rmSync(claudeSkills, { recursive: true, force: true });
+    cleanup();
   }
 });
 
 test("non-existent skills directories are silently skipped", () => {
-  // Ensure neither directory exists so we test the "skip missing" path.
-  const agentsSkills = path.join(os.homedir(), ".agents", "skills");
-  const claudeSkills = path.join(os.homedir(), ".claude", "skills");
-  const existedAgents = fs.existsSync(agentsSkills);
-  const existedClaude = fs.existsSync(claudeSkills);
-  if (existedAgents) fs.rmSync(agentsSkills, { recursive: true, force: true });
-  if (existedClaude) fs.rmSync(claudeSkills, { recursive: true, force: true });
+  // Empty temp HOME — no skills dirs exist, so both should be skipped.
+  const { home, cleanup } = makeSkillsHome();
   try {
-    const r = runCli(["-p", "noop"]);
+    const r = runCli(["-p", "noop"], { extraEnv: { HOME: home } });
     assert.equal(r.status, 0, r.stderr);
     const a = dockerArgs(r.stdout);
     assert.ok(a, "expected DOCKER_INVOKED line");
@@ -799,17 +797,15 @@ test("non-existent skills directories are silently skipped", () => {
       `non-existent .claude/skills must not be mounted: ${a.join(" ")}`,
     );
   } finally {
-    if (existedAgents) fs.mkdirSync(agentsSkills, { recursive: true });
-    if (existedClaude) fs.mkdirSync(claudeSkills, { recursive: true });
+    cleanup();
   }
 });
 
 test("skills mounts work with --file mode", () => {
-  const agentsSkills = path.join(os.homedir(), ".agents", "skills");
-  const created = !fs.existsSync(agentsSkills);
-  if (created) fs.mkdirSync(agentsSkills, { recursive: true });
+  const { home, cleanup } = makeSkillsHome();
+  fs.mkdirSync(path.join(home, ".agents", "skills"), { recursive: true });
   try {
-    const r = runCli(["--file", SAMPLE_FILE, "-p", "noop"]);
+    const r = runCli(["--file", SAMPLE_FILE, "-p", "noop"], { extraEnv: { HOME: home } });
     assert.equal(r.status, 0, r.stderr);
     const a = dockerArgs(r.stdout);
     assert.ok(a, "expected DOCKER_INVOKED line");
@@ -823,7 +819,7 @@ test("skills mounts work with --file mode", () => {
       `expected skills mount in --file mode: ${a.join(" ")}`,
     );
   } finally {
-    if (created) fs.rmSync(agentsSkills, { recursive: true, force: true });
+    cleanup();
   }
 });
 

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -707,3 +707,128 @@ test("opencode interactive (no --ephemeral) creates all three persistence dirs a
     );
   }
 });
+
+// ---- user skills mounting --------------------------------------------------
+
+test("existing ~/.agents/skills is mounted into the container", () => {
+  const agentsSkills = path.join(os.homedir(), ".agents", "skills");
+  // Create the directory if it doesn't exist so the test is deterministic.
+  const created = !fs.existsSync(agentsSkills);
+  if (created) fs.mkdirSync(agentsSkills, { recursive: true });
+  try {
+    const r = runCli(["-p", "noop"]);
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/home/harness/.agents/skills")),
+      `expected .agents/skills mount in: ${a.join(" ")}`,
+    );
+  } finally {
+    if (created) fs.rmSync(agentsSkills, { recursive: true, force: true });
+  }
+});
+
+test("existing ~/.claude/skills is mounted into the container", () => {
+  const claudeSkills = path.join(os.homedir(), ".claude", "skills");
+  const created = !fs.existsSync(claudeSkills);
+  if (created) fs.mkdirSync(claudeSkills, { recursive: true });
+  try {
+    const r = runCli(["-p", "noop"]);
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/home/harness/.claude/skills")),
+      `expected .claude/skills mount in: ${a.join(" ")}`,
+    );
+  } finally {
+    if (created) fs.rmSync(claudeSkills, { recursive: true, force: true });
+  }
+});
+
+test("--no-skills suppresses all skills mounts", () => {
+  const agentsSkills = path.join(os.homedir(), ".agents", "skills");
+  const claudeSkills = path.join(os.homedir(), ".claude", "skills");
+  const createdAgents = !fs.existsSync(agentsSkills);
+  const createdClaude = !fs.existsSync(claudeSkills);
+  if (createdAgents) fs.mkdirSync(agentsSkills, { recursive: true });
+  if (createdClaude) fs.mkdirSync(claudeSkills, { recursive: true });
+  try {
+    const r = runCli(["--no-skills", "-p", "noop"]);
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.equal(
+      a.some((arg) => arg.includes("/.agents/skills")),
+      false,
+      `--no-skills must not mount .agents/skills: ${a.join(" ")}`,
+    );
+    assert.equal(
+      a.some((arg) => arg.includes("/.claude/skills")),
+      false,
+      `--no-skills must not mount .claude/skills: ${a.join(" ")}`,
+    );
+  } finally {
+    if (createdAgents) fs.rmSync(agentsSkills, { recursive: true, force: true });
+    if (createdClaude) fs.rmSync(claudeSkills, { recursive: true, force: true });
+  }
+});
+
+test("non-existent skills directories are silently skipped", () => {
+  // Ensure neither directory exists so we test the "skip missing" path.
+  const agentsSkills = path.join(os.homedir(), ".agents", "skills");
+  const claudeSkills = path.join(os.homedir(), ".claude", "skills");
+  const existedAgents = fs.existsSync(agentsSkills);
+  const existedClaude = fs.existsSync(claudeSkills);
+  if (existedAgents) fs.rmSync(agentsSkills, { recursive: true, force: true });
+  if (existedClaude) fs.rmSync(claudeSkills, { recursive: true, force: true });
+  try {
+    const r = runCli(["-p", "noop"]);
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.equal(
+      a.some((arg) => arg.includes("/.agents/skills")),
+      false,
+      `non-existent .agents/skills must not be mounted: ${a.join(" ")}`,
+    );
+    assert.equal(
+      a.some((arg) => arg.includes("/.claude/skills")),
+      false,
+      `non-existent .claude/skills must not be mounted: ${a.join(" ")}`,
+    );
+  } finally {
+    if (existedAgents) fs.mkdirSync(agentsSkills, { recursive: true });
+    if (existedClaude) fs.mkdirSync(claudeSkills, { recursive: true });
+  }
+});
+
+test("skills mounts work with --file mode", () => {
+  const agentsSkills = path.join(os.homedir(), ".agents", "skills");
+  const created = !fs.existsSync(agentsSkills);
+  if (created) fs.mkdirSync(agentsSkills, { recursive: true });
+  try {
+    const r = runCli(["--file", SAMPLE_FILE, "-p", "noop"]);
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    // The file mount and skills mount should both be present.
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/workspace/script.py")),
+      `expected file mount in: ${a.join(" ")}`,
+    );
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/home/harness/.agents/skills")),
+      `expected skills mount in --file mode: ${a.join(" ")}`,
+    );
+  } finally {
+    if (created) fs.rmSync(agentsSkills, { recursive: true, force: true });
+  }
+});
+
+test("--help documents --no-skills", () => {
+  const r = runCli(["--help"]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /--no-skills/);
+});

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -717,7 +717,10 @@ test("opencode interactive (no --ephemeral) creates all three persistence dirs a
 
 function makeSkillsHome() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "harness-skills-"));
-  return { home: tmp, cleanup: () => fs.rmSync(tmp, { recursive: true, force: true }) };
+  return {
+    home: tmp,
+    cleanup: () => fs.rmSync(tmp, { recursive: true, force: true }),
+  };
 }
 
 test("existing ~/.agents/skills is mounted into the container", () => {
@@ -759,7 +762,9 @@ test("--no-skills suppresses all skills mounts", () => {
   fs.mkdirSync(path.join(home, ".agents", "skills"), { recursive: true });
   fs.mkdirSync(path.join(home, ".claude", "skills"), { recursive: true });
   try {
-    const r = runCli(["--no-skills", "-p", "noop"], { extraEnv: { HOME: home } });
+    const r = runCli(["--no-skills", "-p", "noop"], {
+      extraEnv: { HOME: home },
+    });
     assert.equal(r.status, 0, r.stderr);
     const a = dockerArgs(r.stdout);
     assert.ok(a, "expected DOCKER_INVOKED line");
@@ -805,7 +810,9 @@ test("skills mounts work with --file mode", () => {
   const { home, cleanup } = makeSkillsHome();
   fs.mkdirSync(path.join(home, ".agents", "skills"), { recursive: true });
   try {
-    const r = runCli(["--file", SAMPLE_FILE, "-p", "noop"], { extraEnv: { HOME: home } });
+    const r = runCli(["--file", SAMPLE_FILE, "-p", "noop"], {
+      extraEnv: { HOME: home },
+    });
     assert.equal(r.status, 0, r.stderr);
     const a = dockerArgs(r.stdout);
     assert.ok(a, "expected DOCKER_INVOKED line");


### PR DESCRIPTION
Closes #36

## Summary

Bind-mounts the host user's skills directories into the container so agents can discover and use custom skills:

- `~/.agents/skills` → `/home/harness/.agents/skills`
- `~/.claude/skills` → `/home/harness/.claude/skills`

## Behavior

- **Default**: both directories are mounted (if they exist on the host)
- **Non-existent dirs**: silently skipped (no warning)
- **`--no-skills` flag**: disables all skills mounting
- **All run modes**: applies to interactive, one-shot (`-p` / piped stdin), and `--file` mode

## Changes

- **`src/harness.ts`**: Added `skills` boolean arg, `noSkills` flag parsing, and skills mount logic in `run()`
- **`tests/e2e/cli.test.mjs`**: 6 new e2e tests covering mount presence, `--no-skills` suppression, missing dir skip, `--file` mode, and `--help` documentation
- **`README.md`**: Added "User skills" feature bullet and `--no-skills` to CLI flags table
- **`AGENTS.md`**: Added "User skills" subsystem section and test coverage note

## Tests

All 34 e2e tests pass (28 existing + 6 new).