### PR TITLE
fix: render logo-dark in dark mode on mobile Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="logo-dark.png">
     <source media="(prefers-color-scheme: light)" srcset="logo-light.png">
-    <img src="logo-light.png" alt="harness" width="250" />
+    <img alt="harness" src="logo-light.png#gh-light-mode-only" width="250">
+    <img alt="harness" src="logo-dark.png#gh-dark-mode-only" width="250">
   </picture>
 </p>
 


### PR DESCRIPTION
## Summary
- Mobile Safari does not correctly honor `prefers-color-scheme` in `<picture>` `<source>` elements, causing the light logo to render in dark mode
- Adds `#gh-dark-mode-only` and `#gh-light-mode-only` fragment identifiers to `<img>` tags as a GitHub-supported fallback

## Test Plan
- [ ] Verify in dark mode on mobile Safari
- [ ] Verify light mode still works correctly
- [ ] Verify on desktop browsers (Chrome, Firefox, Safari)

Closes #38