### PR TITLE
fix: logo double render and dark mode mobile Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 <p align="center" style="margin-bottom: 0">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="logo-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="logo-light.png">
-    <img alt="harness" src="logo-light.png#gh-light-mode-only" width="250">
-    <img alt="harness" src="logo-dark.png#gh-dark-mode-only" width="250">
-  </picture>
+  <img alt="harness" src="logo-light.png#gh-light-mode-only" width="250">
+  <img alt="harness" src="logo-dark.png#gh-dark-mode-only" width="250">
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- #39 introduced `#gh-dark-mode-only`/`#gh-light-mode-only` fragments but nested them inside a `<picture>` element, causing the logo to render twice
- GitHub's fragment-based theme toggle relies on its own CSS to hide the non-matching `<img>` — this only works on standalone `<img>` tags, not inside `<picture>`
- Removes the `<picture>` element entirely, keeping only the two `<img>` tags with fragments

## Test Plan
- [ ] Light mode: only `logo-light.png` visible
- [ ] Dark mode: only `logo-dark.png` visible
- [ ] Mobile Safari dark mode: correct dark logo
- [ ] No double rendering

Closes #38