### PR TITLE
feat: add faster-whisper to hermes image for local STT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ The project uses a **multi-image architecture** with a shared base and agent-spe
 |-------|-----------|-------------|----------|
 | Base (pi) | `Dockerfile` | `<version>` | Debian stable-slim, Node.js v24, pnpm, `pi-coding-agent`, `gh`, `mise`, `tini`, `fd`, `ripgrep`, `jq` |
 | OpenCode | `Dockerfile.opencode` | `opencode-<version>` | Base + `opencode-ai` |
-| Hermes | `Dockerfile.hermes` | `hermes-<version>` | Base + `uv`, `cosign`, `tirith`, Python venv with `hermes-agent`, `python-telegram-bot`, `croniter` |
+| Hermes | `Dockerfile.hermes` | `hermes-<version>` | Base + `uv`, `cosign`, `tirith`, Python venv with `hermes-agent`, `python-telegram-bot`, `croniter`, `faster-whisper` |
 
 The image tag is selected at runtime based on `--agent`: pi uses `<version>`, others use `<agent>-<version>`.
 

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -87,7 +87,7 @@ RUN apt-get update && \
         python3 python3-dev python3-venv build-essential git libffi-dev \
     && git clone --depth 1 --branch v2026.4.30 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
     && uv venv /opt/hermes-agent/venv --python python3 \
-    && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent "python-telegram-bot==22.7" "croniter==6.2.2" \
+    && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent "python-telegram-bot==22.7" "croniter==6.2.2" "faster-whisper==1.2.1" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \
     && mkdir -p /etc/harness/hermes-defaults/local/{sessions,logs,hooks,memories,skills,plans,workspace} \
     && mkdir -p /etc/harness/hermes-defaults/openrouter/{sessions,logs,hooks,memories,skills,plans,workspace} \

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ pnpm unlink --global @capotej/harness
 make image
 ```
 
-Builds `ghcr.io/capotej/harness` with Debian stable-slim, Node.js v24, [`@mariozechner/pi-coding-agent`](https://pi.dev/), [`opencode-ai`](https://opencode.ai), [`hermes-agent`](https://github.com/NousResearch/hermes-agent), `fd`, `ripgrep`, `jq`, and `curl`.
+Builds `ghcr.io/capotej/harness` with Debian stable-slim, Node.js v24, [`@mariozechner/pi-coding-agent`](https://pi.dev/), [`opencode-ai`](https://opencode.ai), [`hermes-agent`](https://github.com/NousResearch/hermes-agent), `fd`, `ripgrep`, `jq`, and `curl`. The hermes variant also includes [`faster-whisper`](https://github.com/SYSTRAN/faster-whisper) for local speech-to-text.
 
 The base image is pinned by manifest-list digest (the OCI image index, not a per-platform manifest) for reproducible multi-arch builds. To bump it:
 

--- a/docs/deploying-to-fly.md
+++ b/docs/deploying-to-fly.md
@@ -17,6 +17,9 @@ primary_region = "iad"
 
 [env]
   TZ = "America/New_York"
+  # Persist the faster-whisper model cache across restarts.
+  # Without this, the model re-downloads (~142 MB) on every deploy.
+  HF_HOME = "/home/harness/.hermes-openrouter/.cache/huggingface"
 
 [build]
   image = "ghcr.io/capotej/harness:hermes-1.6.0"

--- a/docs/deploying-to-k8s.md
+++ b/docs/deploying-to-k8s.md
@@ -110,6 +110,10 @@ spec:
               value: "America/New_York"
             - name: HERMES_HOME
               value: "/home/harness/.hermes-openrouter"
+            # Persist the faster-whisper model cache across restarts.
+            # Without this, the model re-downloads (~142 MB) on every pod restart.
+            - name: HF_HOME
+              value: "/home/harness/.hermes-openrouter/.cache/huggingface"
             #
             # add/modify any environment variables here
             #  https://hermes-agent.nousresearch.com/docs/reference/environment-variables


### PR DESCRIPTION
## Summary
- Adds `faster-whisper==1.2.1` to the hermes image's Python venv
- Enables local speech-to-text without requiring external API keys (Groq, OpenAI)
- Subject to the existing 7-day dependency cooldown via `--exclude-newer`

## Changes
- `Dockerfile.hermes` — added `"faster-whisper==1.2.1"` to `uv pip install`
- `AGENTS.md` — updated Hermes image contents table
- `README.md` — noted faster-whisper in image build section

## Test Plan
- [ ] `make image-hermes` builds successfully
- [ ] `faster_whisper` is importable inside the container
- [ ] STT works with `stt.enabled: true` and `stt.provider: local`