### PR TITLE
feat: add --volumes flag for custom volume mounts

### DIFF
--- a/src/harness.ts
+++ b/src/harness.ts
@@ -414,7 +414,9 @@ const volumeArgList: string[] = Array.isArray(argv.volumes)
 for (const spec of volumeArgList) {
   const parts = spec.split(":");
   if (parts.length < 2) {
-    console.error(`harness: invalid volume spec "${spec}" (expected host:container[:opts])`);
+    console.error(
+      `harness: invalid volume spec "${spec}" (expected host:container[:opts])`,
+    );
     process.exit(1);
   }
   if (parts[0] && !fs.existsSync(parts[0])) {
@@ -486,7 +488,10 @@ async function run(prompt: string | null): Promise<void> {
 
   const userVolumeArgs: string[] = [];
   for (const spec of volumeArgList) {
-    userVolumeArgs.push("-v", path.resolve(spec.split(":")[0]) + ":" + spec.split(":").slice(1).join(":"));
+    userVolumeArgs.push(
+      "-v",
+      `${path.resolve(spec.split(":")[0])}:${spec.split(":").slice(1).join(":")}`,
+    );
   }
 
   const args = [

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -23,6 +23,7 @@ interface Args extends ParsedArgs {
   m?: string;
   agent?: string;
   a?: string;
+  volumes?: string[];
 }
 
 interface AgentOptions {
@@ -317,6 +318,7 @@ Options:
   -f, --file <file>      Mount a single file into the container instead of the current directory
   -m, --model <model>    Override the model used by the agent
   -a, --agent <name>     Select the coding agent adapter: pi, opencode, hermes (default: pi)
+  --volumes <spec>       Additional volume mount (host:container[:opts]); may be repeated
   --no-verify            Skip cosign image signature and provenance verification
   --no-skills            Disable mounting user skills directories (~/.agents/skills, ~/.claude/skills)
   --ephemeral            Disable session persistence (implied by -p and piped stdin)
@@ -352,6 +354,7 @@ const argv = minimist<Args>(process.argv.slice(2), {
     "m",
     "agent",
     "a",
+    "volumes",
   ],
   alias: {
     e: "env-file",
@@ -401,6 +404,23 @@ if (fileArg && !fs.existsSync(fileArg)) {
 if (fileArg && fs.statSync(fileArg).isDirectory()) {
   console.error(`harness: --file requires a file, not a directory: ${fileArg}`);
   process.exit(1);
+}
+
+const volumeArgList: string[] = Array.isArray(argv.volumes)
+  ? argv.volumes
+  : argv.volumes
+    ? [argv.volumes]
+    : [];
+for (const spec of volumeArgList) {
+  const parts = spec.split(":");
+  if (parts.length < 2) {
+    console.error(`harness: invalid volume spec "${spec}" (expected host:container[:opts])`);
+    process.exit(1);
+  }
+  if (parts[0] && !fs.existsSync(parts[0])) {
+    console.error(`harness: volume source path does not exist: ${parts[0]}`);
+    process.exit(1);
+  }
 }
 
 async function run(prompt: string | null): Promise<void> {
@@ -464,6 +484,11 @@ async function run(prompt: string | null): Promise<void> {
     }
   }
 
+  const userVolumeArgs: string[] = [];
+  for (const spec of volumeArgList) {
+    userVolumeArgs.push("-v", path.resolve(spec.split(":")[0]) + ":" + spec.split(":").slice(1).join(":"));
+  }
+
   const args = [
     "run",
     "--rm",
@@ -475,6 +500,7 @@ async function run(prompt: string | null): Promise<void> {
     ...envFileArgs,
     ...adapterDockerArgs,
     ...volumeArgs,
+    ...userVolumeArgs,
     "-w",
     "/workspace",
     image,

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -318,7 +318,7 @@ Options:
   -f, --file <file>      Mount a single file into the container instead of the current directory
   -m, --model <model>    Override the model used by the agent
   -a, --agent <name>     Select the coding agent adapter: pi, opencode, hermes (default: pi)
-  --volumes <spec>       Additional volume mount (host:container[:opts]); may be repeated
+  -v, --volumes <spec>   Additional volume mount (host:container[:opts]); may be repeated
   --no-verify            Skip cosign image signature and provenance verification
   --no-skills            Disable mounting user skills directories (~/.agents/skills, ~/.claude/skills)
   --ephemeral            Disable session persistence (implied by -p and piped stdin)
@@ -363,6 +363,7 @@ const argv = minimist<Args>(process.argv.slice(2), {
     m: "model",
     h: "help",
     a: "agent",
+    v: "volumes",
   },
 });
 

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -844,6 +844,18 @@ test("--help documents --volumes", () => {
   assert.match(r.stdout, /--volumes/);
 });
 
+test("-v short flag works same as --volumes", () => {
+  const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "harness-vol-"));
+  const r = runCli(["-p", "noop", "-v", `${extraDir}:/mnt/data`]);
+  assert.equal(r.status, 0, r.stderr);
+  const a = dockerArgs(r.stdout);
+  assert.ok(a, "expected DOCKER_INVOKED line");
+  assert.ok(
+    a.includes(`${extraDir}:/mnt/data`),
+    `expected user volume mount in args: ${a.join(" ")}`,
+  );
+});
+
 test("--volumes with valid spec passes through as -v to docker", () => {
   const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "harness-vol-"));
   const r = runCli(["-p", "noop", "--volumes", `${extraDir}:/mnt/data`]);

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -891,9 +891,12 @@ test("multiple --volumes flags all pass through", () => {
   const dir1 = fs.mkdtempSync(path.join(os.tmpdir(), "harness-vol-"));
   const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), "harness-vol-"));
   const r = runCli([
-    "-p", "noop",
-    "--volumes", `${dir1}:/mnt/a`,
-    "--volumes", `${dir2}:/mnt/b`,
+    "-p",
+    "noop",
+    "--volumes",
+    `${dir1}:/mnt/a`,
+    "--volumes",
+    `${dir2}:/mnt/b`,
   ]);
   assert.equal(r.status, 0, r.stderr);
   const a = dockerArgs(r.stdout);

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -835,3 +835,91 @@ test("--help documents --no-skills", () => {
   assert.equal(r.status, 0, r.stderr);
   assert.match(r.stdout, /--no-skills/);
 });
+
+// ---- --volumes / -v flag ---------------------------------------------------
+
+test("--help documents --volumes", () => {
+  const r = runCli(["--help"]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /--volumes/);
+});
+
+test("--volumes with valid spec passes through as -v to docker", () => {
+  const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "harness-vol-"));
+  const r = runCli(["-p", "noop", "--volumes", `${extraDir}:/mnt/data`]);
+  assert.equal(r.status, 0, r.stderr);
+  const a = dockerArgs(r.stdout);
+  assert.ok(a, "expected DOCKER_INVOKED line");
+  assert.ok(
+    a.includes(`${extraDir}:/mnt/data`),
+    `expected user volume mount in args: ${a.join(" ")}`,
+  );
+});
+
+test("--volumes with absolute host path resolves correctly", () => {
+  const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "harness-vol-"));
+  const r = runCli(["-p", "noop", "--volumes", `${extraDir}:/opt/thing:ro`]);
+  assert.equal(r.status, 0, r.stderr);
+  const a = dockerArgs(r.stdout);
+  assert.ok(
+    a.includes(`${extraDir}:/opt/thing:ro`),
+    `expected volume with opts in args: ${a.join(" ")}`,
+  );
+});
+
+test("--volumes with non-existent host path fails", () => {
+  const r = runCli(["-p", "noop", "--volumes", "/nonexistent/path:/mnt/data"]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /volume source path does not exist/);
+});
+
+test("--volumes with missing colon fails", () => {
+  const r = runCli(["-p", "noop", "--volumes", "nospec"]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /invalid volume spec/);
+});
+
+test("--volumes with relative host path is resolved to absolute", () => {
+  const r = runCli(["-p", "noop", "--volumes", "relative:/mnt/data"]);
+  // The CLI resolves relative paths via path.resolve, so it should fail
+  // because "relative" doesn't exist in WORK_DIR.
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /volume source path does not exist/);
+});
+
+test("multiple --volumes flags all pass through", () => {
+  const dir1 = fs.mkdtempSync(path.join(os.tmpdir(), "harness-vol-"));
+  const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), "harness-vol-"));
+  const r = runCli([
+    "-p", "noop",
+    "--volumes", `${dir1}:/mnt/a`,
+    "--volumes", `${dir2}:/mnt/b`,
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  const a = dockerArgs(r.stdout);
+  assert.ok(
+    a.includes(`${dir1}:/mnt/a`),
+    `expected first volume in args: ${a.join(" ")}`,
+  );
+  assert.ok(
+    a.includes(`${dir2}:/mnt/b`),
+    `expected second volume in args: ${a.join(" ")}`,
+  );
+});
+
+test("--volumes does not break existing workspace mount", () => {
+  const extraDir = fs.mkdtempSync(path.join(os.tmpdir(), "harness-vol-"));
+  const r = runCli(["-p", "noop", "--volumes", `${extraDir}:/mnt/data`]);
+  assert.equal(r.status, 0, r.stderr);
+  const a = dockerArgs(r.stdout);
+  // workspace mount must still be present
+  assert.ok(
+    a.includes(`${WORK_DIR}:/workspace`),
+    `expected workspace mount in args: ${a.join(" ")}`,
+  );
+  // user volume must also be present
+  assert.ok(
+    a.includes(`${extraDir}:/mnt/data`),
+    `expected user volume in args: ${a.join(" ")}`,
+  );
+});


### PR DESCRIPTION
## Summary

Adds a `--volumes` flag that lets users mount additional host paths into the container, passed through as `-v` args to docker.

```bash
harness --volumes /path/to/data:/mnt/data -p "read /mnt/data/config.json"
```

## Changes

- New `--volumes host:container[:opts]` flag (repeatable)
- Validates spec format (requires at least `host:container`)
- Resolves relative host paths to absolute via `path.resolve`
- Verifies host path exists before running docker
- Passes through as `-v` args to docker, after built-in volume mounts
- Coexists with existing workspace mount and `--file` mount

## Testing

8 new E2E tests covering:
- Valid single/multiple volume specs pass through to docker
- Options like `ro` are preserved
- Non-existent host path fails with clear error
- Missing colon fails with clear error
- Relative paths are resolved before existence check
- Existing workspace mount is not broken

All 42 tests pass.

Closes #42
