### PR TITLE
feat: add MCP SDK to hermes image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ The project uses a **multi-image architecture** with a shared base and agent-spe
 |-------|-----------|-------------|----------|
 | Base (pi) | `Dockerfile` | `<version>` | Debian stable-slim, Node.js v24, pnpm, `pi-coding-agent`, `gh`, `mise`, `tini`, `fd`, `ripgrep`, `jq` |
 | OpenCode | `Dockerfile.opencode` | `opencode-<version>` | Base + `opencode-ai` |
-| Hermes | `Dockerfile.hermes` | `hermes-<version>` | Base + `uv`, `cosign`, `tirith`, Python venv with `hermes-agent`, `python-telegram-bot`, `croniter`, `faster-whisper` |
+| Hermes | `Dockerfile.hermes` | `hermes-<version>` | Base + `uv`, `cosign`, `tirith`, Python venv with `hermes-agent` (incl. MCP SDK), `python-telegram-bot`, `croniter`, `faster-whisper` |
 
 The image tag is selected at runtime based on `--agent`: pi uses `<version>`, others use `<agent>-<version>`.
 

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -87,7 +87,7 @@ RUN apt-get update && \
         python3 python3-dev python3-venv build-essential git libffi-dev \
     && git clone --depth 1 --branch v2026.4.30 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
     && uv venv /opt/hermes-agent/venv --python python3 \
-    && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp] "python-telegram-bot==22.7" "croniter==6.2.2" \
+    && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp] "python-telegram-bot==22.7" "croniter==6.2.2" "faster-whisper==1.2.1" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \
     && mkdir -p /etc/harness/hermes-defaults/local/{sessions,logs,hooks,memories,skills,plans,workspace} \
     && mkdir -p /etc/harness/hermes-defaults/openrouter/{sessions,logs,hooks,memories,skills,plans,workspace} \

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -87,7 +87,7 @@ RUN apt-get update && \
         python3 python3-dev python3-venv build-essential git libffi-dev \
     && git clone --depth 1 --branch v2026.4.30 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
     && uv venv /opt/hermes-agent/venv --python python3 \
-    && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent "python-telegram-bot==22.7" "croniter==6.2.2" "faster-whisper==1.2.1" \
+    && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp] "python-telegram-bot==22.7" "croniter==6.2.2" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \
     && mkdir -p /etc/harness/hermes-defaults/local/{sessions,logs,hooks,memories,skills,plans,workspace} \
     && mkdir -p /etc/harness/hermes-defaults/openrouter/{sessions,logs,hooks,memories,skills,plans,workspace} \

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ pnpm unlink --global @capotej/harness
 make image
 ```
 
-Builds `ghcr.io/capotej/harness` with Debian stable-slim, Node.js v24, [`@mariozechner/pi-coding-agent`](https://pi.dev/), [`opencode-ai`](https://opencode.ai), [`hermes-agent`](https://github.com/NousResearch/hermes-agent), `fd`, `ripgrep`, `jq`, and `curl`. The hermes variant also includes [`faster-whisper`](https://github.com/SYSTRAN/faster-whisper) for local speech-to-text.
+Builds `ghcr.io/capotej/harness` with Debian stable-slim, Node.js v24, [`@mariozechner/pi-coding-agent`](https://pi.dev/), [`opencode-ai`](https://opencode.ai), [`hermes-agent`](https://github.com/NousResearch/hermes-agent), `fd`, `ripgrep`, `jq`, and `curl`. The hermes variant also includes the [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) for connecting to MCP servers, and [`faster-whisper`](https://github.com/SYSTRAN/faster-whisper) for local speech-to-text.
 
 The base image is pinned by manifest-list digest (the OCI image index, not a per-platform manifest) for reproducible multi-arch builds. To bump it:
 


### PR DESCRIPTION
## Summary
- Install `hermes-agent[mcp]` extra in the hermes Docker image, adding the MCP Python SDK (`mcp>=1.2.0,<2`)
- Update README.md and AGENTS.md to document MCP SDK availability

## Details
Hermes Agent has a built-in MCP client that connects to MCP servers (stdio and HTTP) at startup, discovers their tools, and makes them available as first-class tools. The MCP SDK was already an optional dependency (`[project.optional-dependencies] mcp`) but was not included in the harness hermes image.

With this change, users can configure `mcp_servers` in their hermes config.yaml and have MCP servers available without any additional setup.

## Test Plan
- [ ] Verify `docker build -f Dockerfile.hermes .` succeeds
- [ ] Verify `pip show mcp` inside the container shows the SDK is installed
- [ ] Verify hermes starts and logs MCP discovery on startup when servers are configured
