### PR TITLE
test(image): pi gets bare tag, opencode/hermes get adapter-prefixed tags

### DIFF
--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -978,3 +978,41 @@ test("--volumes is forwarded alongside --file mode (both mounts present)", () =>
     fs.rmSync(extraDir, { recursive: true, force: true });
   }
 });
+
+test("image tag mapping: pi gets bare tag, opencode/hermes get adapter-prefixed tags", () => {
+  // getImage() at src/harness.ts has an asymmetric rule:
+  //   pi       -> ghcr.io/capotej/harness:<TAG>
+  //   opencode -> ghcr.io/capotej/harness:opencode-<TAG>
+  //   hermes   -> ghcr.io/capotej/harness:hermes-<TAG>
+  //
+  // The existing test at line 309 (`opencode: image tag is "opencode-<version>"`)
+  // only covers the opencode prefix path. Lock the **full mapping** here so
+  // a future refactor can\'t accidentally:
+  //   - add a "pi-" prefix to pi (which would break every existing pi user)
+  //   - drop the prefix for opencode/hermes (which would map all 3 agents
+  //     to the same image)
+  const cases = [
+    { agent: "pi", expectedTag: "test-tag" },
+    { agent: "opencode", expectedTag: "opencode-test-tag" },
+    { agent: "hermes", expectedTag: "hermes-test-tag" },
+  ];
+  for (const { agent, expectedTag } of cases) {
+    const r = runCli(["-a", agent, "-p", "noop"], {
+      extraEnv: { HARNESS_IMAGE_TAG: "test-tag" },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, `expected DOCKER_INVOKED line for ${agent}`);
+    const expectedImage = `ghcr.io/capotej/harness:${expectedTag}`;
+    assert.ok(
+      a.includes(expectedImage),
+      `expected image '${expectedImage}' for agent '${agent}' in: ${a.join(" ")}`,
+    );
+    // Negative: the pi-prefixed form must NEVER appear.
+    assert.equal(
+      a.some((arg) => arg.startsWith("ghcr.io/capotej/harness:pi-")),
+      false,
+      `pi must never get a 'pi-' prefix; got: ${a.join(" ")}`,
+    );
+  }
+});


### PR DESCRIPTION
`getImage()` at `src/harness.ts:339-342` has an asymmetric rule:

```ts
function getImage(agent: string): string {
  const tag = agent === "pi" ? IMAGE_TAG : `${agent}-${IMAGE_TAG}`;
  return `${REGISTRY}:${tag}`;
}
```

- `pi` → `ghcr.io/capotej/harness:<TAG>` (bare)
- `opencode` → `ghcr.io/capotej/harness:opencode-<TAG>`
- `hermes` → `ghcr.io/capotej/harness:hermes-<TAG>`

The existing test at line 309 (`opencode: image tag is "opencode-<version>"`) only covers the opencode prefix path. There's no test locking the **full mapping** with the asymmetric pi-only-without-prefix rule.

A future refactor could regress this two ways:
1. Add a `pi-` prefix to the pi case (would break every existing pi user, since `ghcr.io/capotej/harness:pi-<v>` doesn't get pushed by the release workflow).
2. Drop the prefix for opencode/hermes (would map all 3 agents to the same single-tag image).

Test loops over all 3 agents with `HARNESS_IMAGE_TAG=test-tag`, asserts the exact image string per agent, plus a negative-assert that no `ghcr.io/capotej/harness:pi-*` ever appears in docker args.

44/44 e2e pass locally. No source changes; pure test coverage.
