### PR TITLE
deps: bump hermes-agent v2026.4.30 → v2026.5.7

### DIFF
--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -85,7 +85,7 @@ RUN set -eux && \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         python3 python3-dev python3-venv build-essential git libffi-dev \
-    && git clone --depth 1 --branch v2026.4.30 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
+    && git clone --depth 1 --branch v2026.5.7 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
     && uv venv /opt/hermes-agent/venv --python python3 \
     && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp,web,pty] "python-telegram-bot==22.7" "croniter==6.2.2" "faster-whisper==1.2.1" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \


### PR DESCRIPTION
## Dependency Update

Bumps **hermes-agent** from `v2026.4.30` → `v2026.5.7` (The Tenacity Release)

### Changed
- `Dockerfile.hermes`: git clone branch `v2026.4.30` → `v2026.5.7`

### Dependency check summary

| Dependency | Pinned | Latest | Status |
|---|---|---|---|
| hermes-agent | v2026.4.30 | **v2026.5.7** | ⬆ updated |
| @mariozechner/pi-coding-agent | 0.71.1 | 0.73.1 | 🕏 on cooldown (2d) |
| opencode-ai | 1.14.31 | 1.14.41 | 🕏 on cooldown (2d) |
| pnpm | 10.33.2 | 11.0.9 | 🕏 on cooldown (0d) |
| gh | 2.92.0 | 2.92.0 | ✅ up to date |
| cosign | 3.0.6 | 3.0.6 | ✅ up to date |
| uv | 0.11.8 | 0.11.12 | 🕏 on cooldown (1d) |
| debian:stable-slim | — | — | skipped (no docker)