### PR TITLE
feat: warn on unrecognized CLI flags

### DIFF
--- a/src/harness.ts
+++ b/src/harness.ts
@@ -341,7 +341,7 @@ function getImage(agent: string): string {
   return `${REGISTRY}:${tag}`;
 }
 
-const argv = minimist<Args>(process.argv.slice(2), {
+const MINIMIST_OPTS = {
   boolean: ["help", "h", "ephemeral"],
   string: [
     "env-file",
@@ -365,7 +365,28 @@ const argv = minimist<Args>(process.argv.slice(2), {
     a: "agent",
     v: "volumes",
   },
-});
+};
+
+const argv = minimist<Args>(process.argv.slice(2), MINIMIST_OPTS);
+
+// Warn on unrecognized flags
+{
+  const knownKeys = new Set([
+    "_", // minimist internal positional args
+    ...MINIMIST_OPTS.boolean,
+    ...MINIMIST_OPTS.string,
+    ...Object.keys(MINIMIST_OPTS.alias),
+    ...Object.values(MINIMIST_OPTS.alias),
+    "verify", // --no-verify sets verify=false
+    "skills", // --no-skills sets skills=false
+  ]);
+  const unknown = Object.keys(argv).filter((k) => !knownKeys.has(k));
+  if (unknown.length > 0) {
+    process.stderr.write(
+      `warning: unrecognized flag(s): ${unknown.map((k) => `--${k}`).join(", ")}\n`,
+    );
+  }
+}
 
 if (argv.help) {
   process.stdout.write(USAGE);

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -130,6 +130,18 @@ test("--help documents HARNESS_IMAGE_TAG environment variable", () => {
   assert.match(r.stdout, /HARNESS_IMAGE_TAG[\s\S]*[Dd]ocker image tag/);
 });
 
+test("unrecognized flags emit a warning on stderr", () => {
+  const r = runCli(["--bogus-flag", "--another-fake", "-p", "noop"]);
+  assert.equal(r.status, 0);
+  assert.match(r.stderr, /warning: unrecognized flag\(s\): --bogus-flag, --another-fake/);
+});
+
+test("recognized flags do not emit a warning", () => {
+  const r = runCli(["--no-verify", "-p", "noop"]);
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stderr, /unrecognized flag/);
+});
+
 test("unknown agent fails fast with helpful error", () => {
   const r = runCli(["-a", "bogus-agent", "-p", "noop"]);
   assert.notEqual(r.status, 0);

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -133,7 +133,10 @@ test("--help documents HARNESS_IMAGE_TAG environment variable", () => {
 test("unrecognized flags emit a warning on stderr", () => {
   const r = runCli(["--bogus-flag", "--another-fake", "-p", "noop"]);
   assert.equal(r.status, 0);
-  assert.match(r.stderr, /warning: unrecognized flag\(s\): --bogus-flag, --another-fake/);
+  assert.match(
+    r.stderr,
+    /warning: unrecognized flag\(s\): --bogus-flag, --another-fake/,
+  );
 });
 
 test("recognized flags do not emit a warning", () => {


### PR DESCRIPTION
## Summary
- After minimist parses argv, compare the resulting keys against the known set of flags (booleans, strings, aliases, and `--no-` prefixed variants like `--no-verify`, `--no-skills`)
- Any unrecognized flag emits a `warning: unrecognized flag(s): --foo, --bar` message to stderr
- The program continues to run (warning only, not a hard error) so existing workflows aren't disrupted

## Test Plan
- [x] Added 2 new e2e tests: unrecognized flags warn, recognized flags don't warn
- [x] All 69 tests pass (67 existing + 2 new)
- [x] Manual verification: `--bogus-flag` → warning; `--help` / `--no-verify` → no warning

Closes #45
