### PR TITLE
fix: add git to base image for mise compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ The project uses a **multi-image architecture** with a shared base and agent-spe
 
 | Image | Dockerfile | Tag pattern | Contents |
 |-------|-----------|-------------|----------|
-| Base (pi) | `Dockerfile` | `<version>` | Debian stable-slim, Node.js v24, pnpm, `pi-coding-agent`, `gh`, `mise`, `tini`, `fd`, `ripgrep`, `jq` |
+| Base (pi) | `Dockerfile` | `<version>` | Debian stable-slim, Node.js v24, pnpm, `git`, `pi-coding-agent`, `gh`, `mise`, `tini`, `fd`, `ripgrep`, `jq` |
 | OpenCode | `Dockerfile.opencode` | `opencode-<version>` | Base + `opencode-ai` |
 | Hermes | `Dockerfile.hermes` | `hermes-<version>` | Base + `uv`, `cosign`, `tirith`, Python venv with `hermes-agent` (incl. MCP SDK), `python-telegram-bot`, `croniter`, `faster-whisper` |
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
         ca-certificates \
         curl \
         fd-find \
+        git \
         gnupg \
         jq \
         ripgrep \

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ pnpm unlink --global @capotej/harness
 make image
 ```
 
-Builds `ghcr.io/capotej/harness` with Debian stable-slim, Node.js v24, [`@mariozechner/pi-coding-agent`](https://pi.dev/), [`opencode-ai`](https://opencode.ai), [`hermes-agent`](https://github.com/NousResearch/hermes-agent), `fd`, `ripgrep`, `jq`, and `curl`. The hermes variant also includes the [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) for connecting to MCP servers, and [`faster-whisper`](https://github.com/SYSTRAN/faster-whisper) for local speech-to-text.
+Builds `ghcr.io/capotej/harness` with Debian stable-slim, Node.js v24, `git`, [`@mariozechner/pi-coding-agent`](https://pi.dev/), [`opencode-ai`](https://opencode.ai), [`hermes-agent`](https://github.com/NousResearch/hermes-agent), `fd`, `ripgrep`, `jq`, and `curl`. The hermes variant also includes the [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) for connecting to MCP servers, and [`faster-whisper`](https://github.com/SYSTRAN/faster-whisper) for local speech-to-text.
 
 The base image is pinned by manifest-list digest (the OCI image index, not a per-platform manifest) for reproducible multi-arch builds. To bump it:
 


### PR DESCRIPTION
## Summary
- Added `git` to the `apt-get install` list in the base `Dockerfile`
- Updated `AGENTS.md` and `README.md` to reflect the new dependency

## Why
The `mise.toml` in this repo installs tools from GitHub sources:
```toml
"github:koalaman/shellcheck" = "v0.11.0"
"github:hadolint/hadolint" = "v2.14.0"
"github:rhysd/actionlint" = "v1.7.7"
```
mise requires `git` to clone these repos. Without it, `mise install` fails.

## Test Plan
- [ ] `pr-build.yml` workflow passes (image builds successfully with git installed)
- [ ] Lint passes
- [ ] E2E tests pass

Closes #63
