### PR TITLE
chore(deps): update pinned dependencies (May 2026)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,8 @@ ENV PNPM_HOME=/usr/local/share/pnpm
 ENV PNPM_MINIMUM_RELEASE_AGE=10080
 ENV PATH=$PNPM_HOME:$PATH
 
-RUN corepack enable && corepack prepare pnpm@10.33.2 --activate && \
-    pnpm install -g @mariozechner/pi-coding-agent@0.71.1 && \
+RUN corepack enable && corepack prepare pnpm@11.2.2 --activate && \
+    pnpm install -g @mariozechner/pi-coding-agent@0.73.1 && \
     pnpm store prune && \
     rm -rf ~/.cache/pnpm ~/.npm && \
     mkdir -p /etc/harness/pi-defaults && \

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-RUN pnpm install -g opencode-ai@1.14.31 && \
+RUN pnpm install -g opencode-ai@1.15.10 && \
     pnpm store prune && \
     rm -rf ~/.cache/pnpm ~/.npm
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/capotej/harness.git"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.2.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
Check-deps run for May 22, 2026 — updates 3 pinned dependencies.

### Updated

| Dependency | Pinned | Latest | Cooldown |
|---|---|---|---|
| `@mariozechner/pi-coding-agent` | 0.71.1 | **0.73.1** | ✅ pass |
| `opencode-ai` | 1.14.31 | **1.15.10** | ✅ pass |
| `pnpm` | 10.33.2 | **11.2.2** | ✅ pass |

### Skipped (on cooldown)

| Dependency | Pinned | Latest | Days since release |
|---|---|---|---|
| `hermes-agent` | v2026.5.7 | v2026.5.16 | 6 days |
| `uv` | 0.11.8 | 0.11.16 | 1 day |

### Already up to date
- `gh` 2.92.0 ✓
- `cosign` 3.0.6 ✓
- `debian:stable-slim` ✓

### Changes
- `Dockerfile`: pnpm 10.33.2 → 11.2.2, pi-coding-agent 0.71.1 → 0.73.1
- `Dockerfile.opencode`: opencode-ai 1.14.31 → 1.15.10
- `package.json`: packageManager pnpm@10.33.2 → pnpm@11.2.2

## Test Plan
- [ ] Verify `make image` builds successfully
- [ ] Verify `make image-opencode` builds successfully
- [ ] Verify `pnpm test:e2e` passes