### PR TITLE
Update Dependencies

### DIFF
--- a/.agents/skills/check-deps/SKILL.md
+++ b/.agents/skills/check-deps/SKILL.md
@@ -86,7 +86,7 @@ This project pins eight external dependencies across its Dockerfiles. Check each
 
 ## Notes on specific deps
 
-**uv**: Two things need updating together — `UV_VERSION` and `UV_DIGEST`. When a new version is available, look up its image digest with `docker manifest inspect ghcr.io/astral-sh/uv:<NEW_VERSION> | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['config']['digest'])"` and report both values.
+**uv**: Two things need updating together — `UV_VERSION` and `UV_DIGEST`. The `UV_DIGEST` must be the **multi-arch index digest** (not a per-platform manifest digest). The attestation verification step queries `https://api.github.com/repos/astral-sh/uv/attestations/${UV_DIGEST}`, and attestations are only published at the index level — a per-arch digest will return 404 and break the build. Look up the index digest with `docker buildx imagetools inspect ghcr.io/astral-sh/uv:<NEW_VERSION> 2>&1 | head -4` and take the `Digest:` value from the top-level output (the line after `Name:`). Report both `UV_VERSION` and `UV_DIGEST` values.
 
 **debian:stable-slim**: The digest pins the exact image layer. If `docker pull` reports a different digest than what's in the Dockerfile, the base image has been updated. This requires re-pulling to get the new digest — mention this to the user rather than computing it automatically, since a pull may not always be desirable.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim@sha256:8f0c555de6a2f9c2bda1b170b67479d11f7f5e3b66bb4a7a1d8843361c9dd3ff
+FROM debian:stable-slim@sha256:5012d0517aa0075a7150a45aae67586641e898913b7af3b08228108565b5f90c
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -52,7 +52,7 @@ ENV PNPM_MINIMUM_RELEASE_AGE=10080
 ENV PATH=$PNPM_HOME:$PATH
 
 RUN corepack enable && corepack prepare pnpm@10.33.2 --activate && \
-    pnpm install -g @mariozechner/pi-coding-agent@0.71.1 && \
+    pnpm install -g @mariozechner/pi-coding-agent@0.73.1 && \
     pnpm store prune && \
     rm -rf ~/.cache/pnpm ~/.npm && \
     mkdir -p /etc/harness/pi-defaults && \

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/capotej/harness:latest
-ARG UV_DIGEST=sha256:3b7b60a81d3c57ef471703e5c83fd4aaa33abcd403596fb22ab07db85ae91347
+ARG UV_DIGEST=sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d
 
 FROM ghcr.io/astral-sh/uv@${UV_DIGEST} AS uv-src
 
@@ -7,8 +7,8 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-ARG UV_VERSION=0.11.8
-ARG UV_DIGEST=sha256:3b7b60a81d3c57ef471703e5c83fd4aaa33abcd403596fb22ab07db85ae91347
+ARG UV_VERSION=0.11.16
+ARG UV_DIGEST=sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d
 ARG COSIGN_VERSION=3.0.6
 ARG COSIGN_AMD64_SHA256=c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74
 ARG COSIGN_ARM64_SHA256=bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8
@@ -85,9 +85,9 @@ RUN set -eux && \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         python3 python3-dev python3-venv build-essential git libffi-dev \
-    && git clone --depth 1 --branch v2026.5.7 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
+    && git clone --depth 1 --branch v2026.5.16 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
     && uv venv /opt/hermes-agent/venv --python python3 \
-    && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp,web,pty] "python-telegram-bot==22.7" "croniter==6.2.2" "faster-whisper==1.2.1" \
+    && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp,web,pty] "python-telegram-bot==22.6" "faster-whisper==1.2.1" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \
     && mkdir -p /etc/harness/hermes-defaults/local/{sessions,logs,hooks,memories,skills,plans,workspace} \
     && mkdir -p /etc/harness/hermes-defaults/openrouter/{sessions,logs,hooks,memories,skills,plans,workspace} \

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-RUN pnpm install -g opencode-ai@1.14.31 && \
+RUN pnpm install -g opencode-ai@1.15.10 && \
     pnpm store prune && \
     rm -rf ~/.cache/pnpm ~/.npm
 


### PR DESCRIPTION
- Dockerfile:55 — @mariozechner/pi-coding-agent 0.71.1 → 0.73.1
- Dockerfile.opencode:6 — opencode-ai 1.14.31 → 1.15.10
- Dockerfile.hermes:2,10-11 — uv 0.11.8 → 0.11.16 with new digest
- Dockerfile:1 — debian:stable-slim digest updated
- Dockerfile.hermes:88 — hermes-agent v2026.5.7 → v2026.5.16 (cooldown override)

Two fixes applied:
1. Removed "croniter==6.2.2" — croniter is now a core dependency of hermes-agent (pinned to exactly 6.0.0), so the explicit install conflicts.
2. Downgraded "python-telegram-bot==22.7" to ==22.6" — hermes-agent's [messaging] extra pins 22.6; using 22.7 risks future conflicts or incompatibilities.