### PR TITLE
docs: add RFC format note and propose documentation website

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,18 @@ Run with: `pnpm test:e2e` (requires `pnpm build` first).
 
 The e2e workflow enforces 80% line/branch/function coverage thresholds via Node.js built-in `--experimental-test-coverage`. Locally, run: `pnpm test:coverage` (requires `pnpm build` first).
 
+## RFCs
+
+Significant changes, architectural decisions, and new features should be proposed as RFCs in the `rfcs/` directory. RFCs use the format `rfcs/YYYY-MM-DD_short_title.md` with the following structure:
+
+- `# Title` — short descriptive title
+- `**Date:**` — proposal date (ISO format)
+- `**Status:**` — `Proposed`, `Accepted`, `Implemented`, or `Rejected`
+- `## Goal` — what the RFC aims to accomplish
+- Remaining sections are free-form but typically include motivation, technical details, migration notes, and an implementation checklist
+
+See `rfcs/2025-05-23_agent_persistence.md` for a complete example.
+
 ## Rules
 
 - Keep `README.md` and `AGENTS.md` updated when changing CLI flags, options, architecture, Dockerfiles, CI workflows, or any behavior. If you change how something works, update both files to reflect it.

--- a/rfcs/2025-05-24_documentation_website.md
+++ b/rfcs/2025-05-24_documentation_website.md
@@ -41,10 +41,7 @@ docs/
 │   └── k8s.md              # (moved from docs/deploying-to-k8s.md)
 ├── configuration.md         # CLI flags, env vars, config files
 ├── persistence.md           # XDG persistence explained
-├── security.md              # Cosign verification, seccomp, capabilities
-└── rfcs/                   # Rendered RFCs
-    ├── 2025-05-23_agent_persistence.md
-    └── 2025-05-24_documentation_website.md
+└── security.md              # Cosign verification, seccomp, capabilities
 zensical.toml               # Site configuration
 .github/workflows/docs.yml  # CI/CD workflow
 ```
@@ -98,11 +95,11 @@ jobs:
 - All existing CI/CD workflows are unaffected
 - No changes to CLI, Dockerfiles, or test infrastructure
 
-## Questions
+## Resolved Decisions
 
-- Should the documentation site live in a separate repository (e.g., `capotej/harness-docs`) or in a `docs/` subdirectory of the main repo? This proposal assumes in-repo for simplicity.
-- Should RFCs be automatically included or curated manually?
-- Should the site support versioned docs (one set per release) or just track `main`?
+- **Repository placement:** In-repo, under a `docs/` subdirectory
+- **RFCs:** Omitted from the documentation site (remain in-repo only)
+- **Versioning:** Track `main` only, no per-release versioning
 
 ## Implementation Checklist
 

--- a/rfcs/2025-05-24_documentation_website.md
+++ b/rfcs/2025-05-24_documentation_website.md
@@ -1,0 +1,116 @@
+# Documentation Website: Zensical + GitHub Pages
+
+**Date:** 2025-05-24
+**Status:** Proposed
+
+## Goal
+
+Add a public documentation website for Harness, built with [Zensical](https://github.com/zensical/zensical) (Python-based static site generator) and deployed to GitHub Pages via GitHub Actions.
+
+## Motivation
+
+Harness currently relies on `README.md` and `AGENTS.md` for documentation. A dedicated documentation site would provide:
+
+- Better navigation and discoverability for users evaluating Harness
+- A home for guides, deployment tutorials (`docs/deploying-to-fly.md`, `docs/deploying-to-k8s.md`), and RFCs
+- Versioned documentation tied to releases
+- A more professional landing experience for the project
+
+## Technology
+
+- **Zensical** — Python-based static site generator, installable via `pip install zensical`
+  - Configuration via `zensical.toml`
+  - Content sourced from a `docs/` directory with Markdown + front matter
+  - Output to `site/` directory
+  - Scaffolding via `zensical new .`
+  - Build via `zensical build --clean`
+- **GitHub Pages** — hosted at `https://capotej.github.io/harness/`
+- **GitHub Actions** — automated build and deploy on push to `main`
+
+## Proposed Directory Structure
+
+```text
+docs/
+├── getting-started.md       # Quick start guide
+├── agents/
+│   ├── pi.md               # Pi adapter docs
+│   ├── opencode.md         # OpenCode adapter docs
+│   └── hermes.md           # Hermes adapter docs
+├── deploying/
+│   ├── fly.md              # (moved from docs/deploying-to-fly.md)
+│   └── k8s.md              # (moved from docs/deploying-to-k8s.md)
+├── configuration.md         # CLI flags, env vars, config files
+├── persistence.md           # XDG persistence explained
+├── security.md              # Cosign verification, seccomp, capabilities
+└── rfcs/                   # Rendered RFCs
+    ├── 2025-05-23_agent_persistence.md
+    └── 2025-05-24_documentation_website.md
+zensical.toml               # Site configuration
+.github/workflows/docs.yml  # CI/CD workflow
+```
+
+## GitHub Actions Workflow
+
+```yaml
+name: Deploy Docs
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "zensical.toml"
+      - ".github/workflows/docs.yml"
+      - "README.md"
+permissions:
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  allow-cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install zensical
+      - run: zensical build --clean
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+## What Stays the Same
+
+- `README.md` and `AGENTS.md` remain the primary in-repo references for agents and contributors
+- `docs/deploying-to-fly.md` and `docs/deploying-to-k8s.md` stay in-repo (the website would import or link to them)
+- All existing CI/CD workflows are unaffected
+- No changes to CLI, Dockerfiles, or test infrastructure
+
+## Questions
+
+- Should the documentation site live in a separate repository (e.g., `capotej/harness-docs`) or in a `docs/` subdirectory of the main repo? This proposal assumes in-repo for simplicity.
+- Should RFCs be automatically included or curated manually?
+- Should the site support versioned docs (one set per release) or just track `main`?
+
+## Implementation Checklist
+
+- [ ] Create `zensical.toml` with site metadata and theme config
+- [ ] Scaffold initial documentation pages in `docs/`
+- [ ] Move/adapt existing `docs/deploying-to-*.md` content
+- [ ] Add `.github/workflows/docs.yml` for automated deployment
+- [ ] Configure GitHub Pages on the repository settings
+- [ ] Verify local build with `zensical build --clean`
+- [ ] Verify CI/CD workflow succeeds
+- [ ] Update `README.md` with link to documentation site


### PR DESCRIPTION
## Summary

- **AGENTS.md:** Add an `RFCs` section documenting the expected RFC format (date-stamped filenames, required front matter fields, section structure) with a pointer to the existing agent persistence RFC as a reference example.

- **RFC:** Propose a documentation website built with **Zensical** (Python static site generator) and deployed to **GitHub Pages** via GitHub Actions. Covers proposed directory structure, CI/CD workflow, and open questions about repo placement and versioning.

## Files changed

- `AGENTS.md` — new RFCs section before Rules
- `rfcs/2025-05-24_documentation_website.md` — new RFC

## Checks

- [x] Markdown lint passes (`markdownlint-cli2`)
- [x] E2E tests pass (78/78)
- [x] Build passes (`pnpm build`)