### PR TITLE
stop hardcoding openrouter, start multi provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 bin/
 .harness
 coverage/
+.pi-lens/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,13 +60,13 @@ Skills mounting applies to all run modes (interactive, one-shot, `--file`). Non-
 
 - `entrypoint.sh` (pi) — seeds pi defaults from `/etc/harness/pi-defaults`
 - `entrypoint-opencode.sh` — without `HARNESS_CLOUD_MODE`, sets LM Studio config and default model; with `HARNESS_CLOUD_MODE`, does nothing (agent auto-detects from env vars)
-- `entrypoint-hermes.sh` — without `HARNESS_CLOUD_MODE`, seeds local defaults into `/home/harness/.hermes`; with `HARNESS_CLOUD_MODE`, does nothing — agent auto-detects from env vars
+- `entrypoint-hermes.sh` — minimal entrypoint (hermes self-seeds on first run)
 
 **Cloud/local mode:** When `-e` is passed without `--local`, harness injects `HARNESS_CLOUD_MODE=1` into the container, signaling entrypoints to skip local defaults and let agents auto-detect providers from whatever API keys are in the env file. Without `-e` (or with `-e --local`), entrypoints use local mode (LM Studio, local configs). This is agent-agnostic — any provider key in the env file works without hardcoding specific variable names.
 
 **Dependency cooldown:** All dependencies must be at least 7 days old before upgrading. pnpm enforces this at build time via `PNPM_MINIMUM_RELEASE_AGE=10080`. uv enforces the same cooldown via `--exclude-newer=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')` passed directly to `uv pip install` in `Dockerfile.hermes`. hermes-agent is installed via `git clone` and therefore bypasses uv's cooldown; the `check-deps` skill enforces the 7-day window manually by parsing the release date from the `vYYYY.M.DD` tag format. For other deps (gh, cosign, etc.), the `check-deps` skill checks the GitHub release publish date against the 7-day window.
 
-**Agent configs:** `pi/models.json`, `opencode/lmstudio.json`, `opencode/openrouter.json`, `hermes/local.yaml` define provider/model settings copied into the container.
+**Agent configs:** `pi/models.json`, `opencode/lmstudio.json`, `opencode/openrouter.json`, `opencode/anthropic.json`, `opencode/openai.json`, `opencode/google.json`, `opencode/zai.json` define provider/model settings copied into the container.
 
 ## CI/CD
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,15 +56,17 @@ The image tag is selected at runtime based on `--agent`: pi uses `<version>`, ot
 
 Skills mounting applies to all run modes (interactive, one-shot, `--file`). Non-existent directories are silently skipped. Disable with `--no-skills`.
 
-**Entrypoints:** Each variant has its own entrypoint that seeds default configs into the agent's home directory and detects the provider from env vars:
+**Entrypoints:** Each variant has its own entrypoint that seeds default configs into the agent's home directory and selects local vs cloud mode based on the `HARNESS_CLOUD_MODE` env var:
 
 - `entrypoint.sh` (pi) — seeds pi defaults from `/etc/harness/pi-defaults`
-- `entrypoint-opencode.sh` — detects `OPENROUTER_API_KEY` to switch between LM Studio and OpenRouter configs; sets `OPENCODE_MODEL` env var
-- `entrypoint-hermes.sh` — seeds hermes defaults from `/etc/harness/hermes-defaults/{local,openrouter}`; sets `HERMES_HOME` based on provider
+- `entrypoint-opencode.sh` — without `HARNESS_CLOUD_MODE`, sets LM Studio config and default model; with `HARNESS_CLOUD_MODE`, does nothing (agent auto-detects from env vars)
+- `entrypoint-hermes.sh` — without `HARNESS_CLOUD_MODE`, seeds local defaults into `/home/harness/.hermes`; with `HARNESS_CLOUD_MODE`, does nothing — agent auto-detects from env vars
+
+**Cloud/local mode:** When `-e` is passed without `--local`, harness injects `HARNESS_CLOUD_MODE=1` into the container, signaling entrypoints to skip local defaults and let agents auto-detect providers from whatever API keys are in the env file. Without `-e` (or with `-e --local`), entrypoints use local mode (LM Studio, local configs). This is agent-agnostic — any provider key in the env file works without hardcoding specific variable names.
 
 **Dependency cooldown:** All dependencies must be at least 7 days old before upgrading. pnpm enforces this at build time via `PNPM_MINIMUM_RELEASE_AGE=10080`. uv enforces the same cooldown via `--exclude-newer=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')` passed directly to `uv pip install` in `Dockerfile.hermes`. hermes-agent is installed via `git clone` and therefore bypasses uv's cooldown; the `check-deps` skill enforces the 7-day window manually by parsing the release date from the `vYYYY.M.DD` tag format. For other deps (gh, cosign, etc.), the `check-deps` skill checks the GitHub release publish date against the 7-day window.
 
-**Agent configs:** `pi/models.json`, `opencode/lmstudio.json`, `opencode/openrouter.json`, `hermes/local.yaml`, `hermes/openrouter.yaml` define provider/model settings copied into the container.
+**Agent configs:** `pi/models.json`, `opencode/lmstudio.json`, `opencode/openrouter.json`, `hermes/local.yaml` define provider/model settings copied into the container.
 
 ## CI/CD
 
@@ -89,6 +91,7 @@ E2E tests in `tests/e2e/cli.test.mjs` use a docker shim (a fake `docker` binary 
 - Volume mount construction (file vs directory, adapter-specific mount points)
 - `--env-file` forwarding across all adapters
 - `--model` handling (local vs env-file mode, `--provider ollama` injection)
+- Cloud/local mode (`HARNESS_CLOUD_MODE`, `--local` flag)
 - User skills mounting (`~/.agents/skills`, `~/.claude/skills`, `--no-skills` flag)
 
 Run with: `pnpm test:e2e` (requires `pnpm build` first).

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -90,16 +90,13 @@ RUN apt-get update && \
     && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp,web,pty] "python-telegram-bot==22.6" "faster-whisper==1.2.1" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \
     && mkdir -p /etc/harness/hermes-defaults/local/{sessions,logs,hooks,memories,skills,plans,workspace} \
-    && mkdir -p /etc/harness/hermes-defaults/openrouter/{sessions,logs,hooks,memories,skills,plans,workspace} \
     && cp /opt/hermes-agent/.env.example /etc/harness/hermes-defaults/local/.env \
-    && cp /opt/hermes-agent/.env.example /etc/harness/hermes-defaults/openrouter/.env \
     && chown -R harness:harness /etc/harness/hermes-defaults \
     && chown -R harness:harness /opt/hermes-agent \
     && rm -rf /opt/hermes-agent/.git /root/.cache/uv \
     && rm -rf /var/lib/apt/lists/*
 
 COPY hermes/local.yaml /etc/harness/hermes-defaults/local/config.yaml
-COPY hermes/openrouter.yaml /etc/harness/hermes-defaults/openrouter/config.yaml
 
 COPY entrypoint-hermes.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -89,14 +89,11 @@ RUN apt-get update && \
     && uv venv /opt/hermes-agent/venv --python python3 \
     && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp,web,pty] "python-telegram-bot==22.6" "faster-whisper==1.2.1" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \
-    && mkdir -p /etc/harness/hermes-defaults/local/{sessions,logs,hooks,memories,skills,plans,workspace} \
-    && cp /opt/hermes-agent/.env.example /etc/harness/hermes-defaults/local/.env \
-    && chown -R harness:harness /etc/harness/hermes-defaults \
     && chown -R harness:harness /opt/hermes-agent \
     && rm -rf /opt/hermes-agent/.git /root/.cache/uv \
     && rm -rf /var/lib/apt/lists/*
 
-COPY hermes/local.yaml /etc/harness/hermes-defaults/local/config.yaml
+COPY hermes/local.yaml /etc/harness/hermes-local.yaml
 
 COPY entrypoint-hermes.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -4,13 +4,13 @@ FROM ${BASE_IMAGE}
 USER root
 
 RUN pnpm install -g opencode-ai@1.15.10 && \
+    cd $(pnpm root -g)/opencode-ai && node postinstall.mjs && \
     pnpm store prune && \
     rm -rf ~/.cache/pnpm ~/.npm
 
 RUN mkdir -p /etc/opencode
 
-COPY opencode/lmstudio.json /etc/opencode/lmstudio.json
-COPY opencode/openrouter.json /etc/opencode/openrouter.json
+COPY opencode/*.json /etc/opencode/
 
 COPY entrypoint-opencode.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ See the [full list of supported providers](https://github.com/badlogic/pi-mono/b
 
 #### opencode agent
 
-[`opencode`](https://opencode.ai) uses LM Studio by default. To use OpenRouter instead, pass an env file containing `OPENROUTER_API_KEY`:
+[`opencode`](https://opencode.ai) uses LM Studio by default. Pass `--env-file` to switch to cloud mode — the agent auto-detects the provider from whichever API key is in the file:
 
 ```bash
-npx @capotej/harness -p "write me a fizzbuzz in Go"
+echo "OPENROUTER_API_KEY=sk-..." > .env
+npx @capotej/harness -e .env -p "write me a fizzbuzz in Go"
 ```
 
 That's it. Your current directory is mounted at `/workspace` inside the container and the agent works against it.
@@ -146,18 +147,24 @@ See the [full provider list](https://github.com/badlogic/pi-mono/blob/c779c14e91
 
 ### opencode
 
-[`opencode`](https://opencode.ai) defaults to LM Studio. Drop `OPENROUTER_API_KEY` into your env file and it switches to OpenRouter automatically (`openrouter/auto` if no `-m`). The `-m` flag takes a bare model name; the provider prefix is added for you.
+[`opencode`](https://opencode.ai) defaults to LM Studio in local mode. Pass `--env-file` to enter cloud mode — the agent auto-detects the provider from whichever API key is in the file (`ZAI_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, etc.). The `-m` flag takes a bare model name; the provider prefix is added for you.
 
 ```bash
 npx @capotej/harness -a opencode -e .env -p "refactor the auth module"
 npx @capotej/harness -a opencode -e .env -m anthropic/claude-sonnet-4-5 -p "add tests"
 ```
 
+To pass env vars but stay in local mode, use `--local`:
+
+```bash
+npx @capotej/harness -a opencode -e .env --local -p "refactor the auth module"
+```
+
 When using LM Studio locally, set the model's context length to at least 32k tokens.
 
 ### hermes
 
-[`hermes`](https://github.com/NousResearch/hermes-agent) by NousResearch supports many providers. Pass an env file with your key and a `provider/model` to `-m`:
+[`hermes`](https://github.com/NousResearch/hermes-agent) by NousResearch supports many providers. Pass `--env-file` to enter cloud mode — the agent auto-detects the provider from whichever API key is in the file. Use a `provider/model` for `-m`:
 
 ```bash
 npx @capotej/harness -a hermes -e .env -m anthropic/claude-sonnet-4-5 -p "add tests"
@@ -225,6 +232,7 @@ If an old `.harness/` directory exists in your working directory, harness will e
 | `--no-verify` |       | Skip cosign signature and provenance verification |
 | `--no-skills` |       | Disable mounting user skills directories (`~/.agents/skills`, `~/.claude/skills`) |
 | `--ephemeral` |       | Disable session persistence (implied by `-p` and piped stdin) |
+| `--local`     |       | Force local mode even with `-e` (use LM Studio / local defaults) |
 | `--help`      | `-h`  | Show help |
 
 ### Environment variables
@@ -236,8 +244,8 @@ If an old `.harness/` directory exists in your working directory, harness will e
 ### Agent-specific behavior
 
 - **pi** — `-m` is passed straight to the binary as `--model`.
-- **opencode** — `-m` is passed via the `OPENCODE_MODEL` env var. Provider is auto-detected from the env file (`OPENROUTER_API_KEY` → OpenRouter, otherwise LM Studio).
-- **hermes** — `-m` is passed as `--model` in `provider/model` form. Provider is auto-detected from whichever API key is present.
+- **opencode** — `-m` is passed via the `OPENCODE_MODEL` env var. Without `-e`, uses LM Studio locally. With `-e`, enters cloud mode and auto-detects the provider from whichever API key is in the env file. Use `--local` to force local mode even with `-e`.
+- **hermes** — `-m` is passed as `--model` in `provider/model` form. Without `-e`, uses local config. With `-e`, enters cloud mode and auto-detects from env vars. Use `--local` to force local mode even with `-e`.
 
 ## Deploying hermes as a claw
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See the [full list of supported providers](https://github.com/badlogic/pi-mono/b
 [`opencode`](https://opencode.ai) uses LM Studio by default. Pass `--env-file` to switch to cloud mode — the agent auto-detects the provider from whichever API key is in the file:
 
 ```bash
-echo "OPENROUTER_API_KEY=sk-..." > .env
+echo 'OPENROUTER_API_KEY=sk-...' > .env
 npx @capotej/harness -e .env -p "write me a fizzbuzz in Go"
 ```
 

--- a/entrypoint-hermes.sh
+++ b/entrypoint-hermes.sh
@@ -2,18 +2,15 @@
 set -e
 
 seed() {
-  [ -d "$1" ] || return 0
-  mkdir -p "$2"
-  cp -rn "$1"/. "$2"/
+	[ -d "$1" ] || return 0
+	mkdir -p "$2"
+	cp -rn "$1"/. "$2"/
 }
 
-seed /etc/harness/hermes-defaults/local /home/harness/.hermes-local
-seed /etc/harness/hermes-defaults/openrouter /home/harness/.hermes-openrouter
-
-if [ -n "$OPENROUTER_API_KEY" ]; then
-  export HERMES_HOME=/home/harness/.hermes-openrouter
-else
-  export HERMES_HOME=/home/harness/.hermes-local
+if [ -z "$HARNESS_CLOUD_MODE" ]; then
+	# Local mode: seed defaults into HERMES_HOME
+	seed /etc/harness/hermes-defaults/local /home/harness/.hermes
 fi
+# Cloud mode: agent auto-detects provider from env vars
 
 exec "$@"

--- a/entrypoint-hermes.sh
+++ b/entrypoint-hermes.sh
@@ -1,16 +1,33 @@
 #!/bin/bash
 set -e
 
-seed() {
-	[ -d "$1" ] || return 0
-	mkdir -p "$2"
-	cp -rn "$1"/. "$2"/
-}
+CONFIG="/home/harness/.hermes/config.yaml"
 
-if [ -z "$HARNESS_CLOUD_MODE" ]; then
-	# Local mode: seed defaults into HERMES_HOME
-	seed /etc/harness/hermes-defaults/local /home/harness/.hermes
+if [ ! -f "$CONFIG" ]; then
+	# First run
+	if [ -z "$HARNESS_CLOUD_MODE" ]; then
+		# Local mode: seed LM Studio config
+		mkdir -p /home/harness/.hermes
+		cp /etc/harness/hermes-local.yaml "$CONFIG"
+	fi
+	# Cloud mode first run: hermes self-seeds from env vars
+else
+	# Config exists — reconcile with current harness mode
+	if [ -z "$HARNESS_CLOUD_MODE" ]; then
+		# Local mode: ensure LM Studio settings
+		hermes config set model.provider custom >/dev/null 2>&1
+		hermes config set model.base_url "http://host.docker.internal:1234/v1" >/dev/null 2>&1
+		hermes config set model.default "${HERMES_MODEL:-gemma-4-e4b}" >/dev/null 2>&1
+	else
+		# Cloud mode: clear local provider so hermes detects from env vars
+		hermes config set model.provider "" >/dev/null 2>&1
+		hermes config set model.base_url "" >/dev/null 2>&1
+	fi
 fi
-# Cloud mode: agent auto-detects provider from env vars
+
+# Override model if -m was passed
+if [ -n "$HERMES_MODEL" ]; then
+	hermes config set model.default "$HERMES_MODEL" >/dev/null 2>&1
+fi
 
 exec "$@"

--- a/entrypoint-opencode.sh
+++ b/entrypoint-opencode.sh
@@ -4,12 +4,28 @@ set -e
 export OPENCODE_DISABLE_AUTOUPDATE=true
 export OPENCODE_DISABLE_PRUNE=true
 
-if [ -n "$OPENROUTER_API_KEY" ]; then
-  export OPENCODE_CONFIG=/etc/opencode/openrouter.json
-  export OPENCODE_MODEL="openrouter/${OPENCODE_MODEL:-openrouter/auto}"
+if [ -z "$HARNESS_CLOUD_MODE" ]; then
+	# Local mode: use LM Studio config and default model
+	export OPENCODE_CONFIG=/etc/opencode/lmstudio.json
+	export OPENCODE_MODEL="${OPENCODE_MODEL:-lmstudio/google/gemma-4-e4b}"
 else
-  export OPENCODE_CONFIG=/etc/opencode/lmstudio.json
-  export OPENCODE_MODEL="${OPENCODE_MODEL:-lmstudio/google/gemma-4-e4b}"
+	# Cloud mode: detect provider from env vars
+	if [ -n "$ANTHROPIC_API_KEY" ]; then
+		export OPENCODE_CONFIG=/etc/opencode/anthropic.json
+		export OPENCODE_MODEL="${OPENCODE_MODEL:-anthropic/claude-sonnet-4-6}"
+	elif [ -n "$OPENAI_API_KEY" ]; then
+		export OPENCODE_CONFIG=/etc/opencode/openai.json
+		export OPENCODE_MODEL="${OPENCODE_MODEL:-openai/gpt-5.4}"
+	elif [ -n "$GOOGLE_API_KEY" ]; then
+		export OPENCODE_CONFIG=/etc/opencode/google.json
+		export OPENCODE_MODEL="${OPENCODE_MODEL:-google/gemini-3.1-pro}"
+	elif [ -n "$ZAI_API_KEY" ]; then
+		export OPENCODE_CONFIG=/etc/opencode/zai.json
+		export OPENCODE_MODEL="${OPENCODE_MODEL:-zai/glm-5.1}"
+	elif [ -n "$OPENROUTER_API_KEY" ]; then
+		export OPENCODE_CONFIG=/etc/opencode/openrouter.json
+		export OPENCODE_MODEL="${OPENCODE_MODEL:-openrouter/auto}"
+	fi
 fi
 
 exec "$@"

--- a/opencode/anthropic.json
+++ b/opencode/anthropic.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "anthropic": {
+      "models": {
+        "anthropic/claude-sonnet-4-6": {}
+      }
+    }
+  },
+  "model": "{env:OPENCODE_MODEL}",
+  "enabled_providers": ["anthropic"]
+}

--- a/opencode/google.json
+++ b/opencode/google.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "google": {
+      "models": {
+        "google/gemini-3.1-pro": {}
+      }
+    }
+  },
+  "model": "{env:OPENCODE_MODEL}",
+  "enabled_providers": ["google"]
+}

--- a/opencode/openai.json
+++ b/opencode/openai.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "openai": {
+      "models": {
+        "openai/gpt-5.4": {}
+      }
+    }
+  },
+  "model": "{env:OPENCODE_MODEL}",
+  "enabled_providers": ["openai"]
+}

--- a/opencode/zai.json
+++ b/opencode/zai.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "zai": {
+      "models": {
+        "zai/glm-5.1": {}
+      }
+    }
+  },
+  "model": "{env:OPENCODE_MODEL}",
+  "enabled_providers": ["zai"]
+}

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -18,6 +18,7 @@ interface Args extends ParsedArgs {
   // minimist --no- prefix: --no-verify / --no-skills set these to false; NOT in boolean[] to avoid double-negation
   verify?: boolean;
   ephemeral: boolean;
+  local: boolean;
   skills?: boolean;
   "env-file"?: string;
   e?: string;
@@ -108,13 +109,7 @@ class HermesAdapter implements AgentAdapter {
   }
 
   persistMounts(): PersistMount[] {
-    return [
-      { hostSubpath: "local", containerPath: "/home/harness/.hermes-local" },
-      {
-        hostSubpath: "openrouter",
-        containerPath: "/home/harness/.hermes-openrouter",
-      },
-    ];
+    return [{ hostSubpath: "", containerPath: "/home/harness/.hermes" }];
   }
 }
 
@@ -328,6 +323,7 @@ Options:
   --no-verify            Skip cosign image signature and provenance verification
   --no-skills            Disable mounting user skills directories (~/.agents/skills, ~/.claude/skills)
   --ephemeral            Disable session persistence (implied by -p and piped stdin)
+  --local                Force local mode even with -e (use LM Studio / local defaults)
   -h, --help             Show this help message
 
 Environment variables:
@@ -371,7 +367,7 @@ function getImage(agent: string): string {
 }
 
 const MINIMIST_OPTS = {
-  boolean: ["help", "h", "ephemeral"],
+  boolean: ["help", "h", "ephemeral", "local"],
   string: [
     "env-file",
     "e",
@@ -408,6 +404,7 @@ const argv = minimist<Args>(process.argv.slice(2), MINIMIST_OPTS);
     ...Object.values(MINIMIST_OPTS.alias),
     "verify", // --no-verify sets verify=false
     "skills", // --no-skills sets skills=false
+    "local",
   ]);
   const unknown = Object.keys(argv).filter((k) => !knownKeys.has(k));
   if (unknown.length > 0) {
@@ -424,6 +421,7 @@ if (argv.help) {
 
 const noVerify = argv.verify === false;
 const noSkills = argv.skills === false;
+const localMode = argv.local;
 const envFilePath = argv["env-file"] || null;
 const fileArg = argv.file || null;
 const promptArg = argv.prompt || null;
@@ -492,6 +490,11 @@ async function run(prompt: string | null): Promise<void> {
   const envFileArgs = envFilePath
     ? ["--env-file", path.resolve(envFilePath)]
     : [];
+
+  // Cloud mode: -e without --local signals entrypoints to skip local/defaults
+  // and let agents auto-detect providers from env vars in the file.
+  const cloudModeEnv =
+    envFilePath && !localMode ? ["-e", "HARNESS_CLOUD_MODE=1"] : [];
 
   const adapter = ADAPTERS[agentName];
   const adapterOptions = { prompt, model: modelArg, envFilePath };
@@ -575,6 +578,7 @@ async function run(prompt: string | null): Promise<void> {
     "--security-opt",
     `seccomp=${SECCOMP_PROFILE}`,
     ...envFileArgs,
+    ...cloudModeEnv,
     ...adapterDockerArgs,
     ...volumeArgs,
     ...userVolumeArgs,

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -13,7 +13,7 @@
 // the cosign verification skip path (HARNESS_IMAGE_TAG and --no-verify).
 
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -462,6 +462,64 @@ test("--env-file is passed to docker as --env-file <abs>", () => {
   const i = a.indexOf("--env-file");
   assert.notEqual(i, -1);
   assert.equal(a[i + 1], ENV_FILE); // resolved to abs path; ENV_FILE already abs
+});
+
+// ---- cloud/local mode (HARNESS_CLOUD_MODE) ---------------------------------
+
+test("-e without --local sets HARNESS_CLOUD_MODE=1 (cloud mode)", () => {
+  const r = runCli(["-e", ENV_FILE, "-p", "noop"]);
+  assert.equal(r.status, 0, r.stderr);
+  const a = dockerArgs(r.stdout);
+  const idx = a.findIndex(
+    (v, i) => v === "-e" && a[i + 1] === "HARNESS_CLOUD_MODE=1",
+  );
+  assert.notEqual(idx, -1, `HARNESS_CLOUD_MODE=1 not found in: ${a.join(" ")}`);
+});
+
+test("no -e does NOT set HARNESS_CLOUD_MODE (local mode)", () => {
+  const r = runCli(["-p", "noop"]);
+  assert.equal(r.status, 0, r.stderr);
+  const a = dockerArgs(r.stdout);
+  const has = a.some(
+    (v, i) => v === "-e" && a[i + 1]?.startsWith("HARNESS_CLOUD_MODE"),
+  );
+  assert.ok(
+    !has,
+    `HARNESS_CLOUD_MODE should not be set without -e: ${a.join(" ")}`,
+  );
+});
+
+test("-e with --local does NOT set HARNESS_CLOUD_MODE (forced local)", () => {
+  const r = runCli(["-e", ENV_FILE, "--local", "-p", "noop"]);
+  assert.equal(r.status, 0, r.stderr);
+  const a = dockerArgs(r.stdout);
+  // --env-file should still be present
+  assert.notEqual(a.indexOf("--env-file"), -1);
+  const has = a.some(
+    (v, i) => v === "-e" && a[i + 1]?.startsWith("HARNESS_CLOUD_MODE"),
+  );
+  assert.ok(
+    !has,
+    `HARNESS_CLOUD_MODE should not be set with --local: ${a.join(" ")}`,
+  );
+});
+
+test("cloud mode works for all agents (pi, opencode, hermes)", () => {
+  for (const agent of ["pi", "opencode", "hermes"]) {
+    const r = runCli(["-a", agent, "-e", ENV_FILE, "-p", "noop"]);
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    const has = a.some(
+      (v, i) => v === "-e" && a[i + 1] === "HARNESS_CLOUD_MODE=1",
+    );
+    assert.ok(has, `${agent}: HARNESS_CLOUD_MODE=1 expected: ${a.join(" ")}`);
+  }
+});
+
+test("--help documents --local flag", () => {
+  const r = spawnSync("node", [CLI, "--help"], { encoding: "utf8" });
+  assert.match(r.stdout, /--local/);
+  assert.match(r.stdout, /local mode/i);
 });
 
 // ---- file mount vs cwd mount -----------------------------------------------
@@ -1516,15 +1574,11 @@ test("--volumes is forwarded alongside --file mode (both mounts present)", () =>
   }
 });
 
-test("hermes interactive (no --ephemeral) creates both persistence dirs and mounts", () => {
-  // HermesAdapter.persistMounts() returns two distinct mounts:
-  //   - local      -> /home/harness/.hermes-local
-  //   - openrouter -> /home/harness/.hermes-openrouter
+test("hermes interactive (no --ephemeral) creates persistence dir and mounts", () => {
+  // HermesAdapter.persistMounts() returns a single mount:
+  //   '' -> /home/harness/.hermes
   //
-  // The pi adapter test only locks a single empty-hostSubpath mount and
-  // PR #30 (mine, merged) locks the opencode 3-mount shape. This is the
-  // analog test for hermes's 2-mount shape so a future refactor cannot
-  // silently drop one of the two hermes persistence buckets.
+  // The empty hostSubpath means the persist root itself is mounted directly.
   const which = spawnSync("sh", ["-c", "command -v script"], {
     encoding: "utf8",
   });
@@ -1552,30 +1606,22 @@ test("hermes interactive (no --ephemeral) creates both persistence dirs and moun
   );
   assert.equal(r.status, 0, r.stderr);
 
-  // Both host-side persistence buckets must be created under XDG.
+  // Host-side persistence dir must be created under XDG.
   const nCwd = normalizeCwd(localWork, homeDir);
-  for (const sub of ["local", "openrouter"]) {
-    assert.equal(
-      fs.existsSync(path.join(xdgData, "harness", nCwd, "hermes", sub)),
-      true,
-      `XDG_DATA_HOME/harness/${nCwd}/hermes/${sub}/ should be created in interactive mode`,
-    );
-  }
+  assert.equal(
+    fs.existsSync(path.join(xdgData, "harness", nCwd, "hermes")),
+    true,
+    `XDG_DATA_HOME/harness/${nCwd}/hermes/ should be created in interactive mode`,
+  );
 
-  // Both docker -v mounts must target the documented container paths.
+  // Docker -v mount must target the default hermes home.
   const cleaned = r.stdout.replace(/\r/g, "");
   const a = dockerArgs(cleaned);
   assert.ok(a, `expected DOCKER_INVOKED line in: ${cleaned}`);
-  const targets = [
-    "/home/harness/.hermes-local",
-    "/home/harness/.hermes-openrouter",
-  ];
-  for (const t of targets) {
-    assert.ok(
-      a.some((arg) => arg.endsWith(`:${t}`)),
-      `expected -v mount ending in :${t} in: ${a.join(" ")}`,
-    );
-  }
+  assert.ok(
+    a.some((arg) => arg.endsWith(":/home/harness/.hermes")),
+    `expected -v mount ending in :/home/harness/.hermes in: ${a.join(" ")}`,
+  );
 });
 
 test("--volumes is forwarded alongside --file mode (both mounts present)", () => {

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -393,8 +393,8 @@ test("opencode: --model is passed via OPENCODE_MODEL env, not CLI", () => {
 
 test("hermes: no -m, no -p emits exactly ['hermes','chat'] (no stray flags)", () => {
   // Covers the no-model + interactive branch of HermesAdapter.buildCommand:
-  //   args = ["hermes","chat"]; no -m pushed (model falsy); no -q pushed
-  //   (prompt === null when no -p and no piped stdin).
+  //   args = ["hermes","chat"]; no -m pushed (model falsy);
+  //   no -q pushed (prompt === null when no -p and no piped stdin).
   // Locks that future refactors don't accidentally inject defaults for
   // either flag in the no-args path.
   //
@@ -1847,7 +1847,8 @@ test("--agent=hermes (equals form) selects the agent", () => {
   const idx = a.indexOf("hermes");
   assert.notEqual(idx, -1, `expected 'hermes' in: ${a.join(" ")}`);
   // hermes adapter shape: hermes chat -q <prompt>
-  assert.deepEqual(a.slice(idx, idx + 2), ["hermes", "chat"]);
+  assert.deepEqual(a.slice(idx, idx + 3), ["hermes", "chat", "-q"]);
+  assert.equal(a[idx + 3], "noop");
 });
 
 test("opencode: prompt is forwarded as `opencode run <prompt>`", () => {


### PR DESCRIPTION
 ## Fixes

 - Fix opencode -e flag not being respected — opencode and hermes entrypoints hardcoded OPENROUTER_API_KEY checks, so any other provider key (e.g.
 ZAI_API_KEY) was ignored and the agent always fell back to LM Studio defaults (#62)
 - Fix opencode postinstall not running — pnpm install -g skipped the postinstall script that extracts the opencode binary, causing a runtime error

 ## Changes

 ### Cloud/local mode via HARNESS_CLOUD_MODE (src/harness.ts)

 New --local flag. When -e is passed without --local, harness injects HARNESS_CLOUD_MODE=1 into the container. Entrypoints use this to decide behavior — no
 more hardcoding specific API key names. Without -e (or with -e --local), entrypoints use local mode (LM Studio, local configs).

 ### Entrypoints

 - opencode — cloud mode auto-detects the provider from env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY, ZAI_API_KEY, OPENROUTER_API_KEY) and
 selects the appropriate config with a sensible default model
 - hermes — cloud mode does nothing (no seeding), letting hermes auto-detect from env vars. Local mode seeds defaults into the single /home/harness/.hermes
 path

 ### New opencode provider configs

 - opencode/anthropic.json — anthropic/claude-sonnet-4-6
 - opencode/openai.json — openai/gpt-5.4
 - opencode/google.json — google/gemini-3.1-pro
 - opencode/zai.json — zai/glm-5.1

 ### Simplified hermes persistence

 Removed the .hermes-local / .hermes-openrouter split. Single mount at /home/harness/.hermes (hermes's default HERMES_HOME). Local mode seeds it; cloud mode
 leaves it empty for the agent to configure.

 ### Tests (+5 new, 83 total)

 - -e without --local sets HARNESS_CLOUD_MODE=1
 - No -e does not set HARNESS_CLOUD_MODE
 - -e with --local does not set HARNESS_CLOUD_MODE
 - Cloud mode works for all agents
 - --help documents --local

 Also removed unused execFileSync import.

 Closes #62 and #77