### PR TITLE
persist the global npm local for pi for faster restarts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ The image tag is selected at runtime based on `--agent`: pi uses `<version>`, ot
 
 **Cosign image verification (`verifyImage`):** On every run (unless `--no-verify` or `HARNESS_IMAGE_TAG` is set), harness verifies the container image was signed by the official CI workflow and carries a valid SLSA provenance attestation. Verified digests are cached at `~/.cache/harness/cosign-verified.json`. Requires `cosign` installed on the host.
 
-**Persistence:** Interactive runs (no `-p`, no piped stdin, no `--ephemeral`) store persistence data at `$XDG_DATA_HOME/harness/<normalized-cwd>/<agent>/` (defaults to `~/.local/share/harness/`). The `<normalized-cwd>` is computed by `normalizeCwd()`: strips `os.homedir()` prefix, replaces `/` with `_`, uses `_home` if empty. Each adapter declares its own mount points via `persistMounts()`. Per-agent `mise` data is persisted via two volume mounts: `<persist-root>/mise/` → `/home/harness/.local/share/mise` (tools/plugins, `MISE_DATA_DIR`) and `<persist-root>/mise-state/` → `/home/harness/.local/state/mise` (trust settings, `MISE_STATE_DIR`). One-shot runs are implicitly ephemeral. A deprecation warning is emitted if an old `.harness/` directory exists in the CWD.
+**Persistence:** Interactive runs (no `-p`, no piped stdin, no `--ephemeral`) store persistence data at `$XDG_DATA_HOME/harness/<normalized-cwd>/<agent>/` (defaults to `~/.local/share/harness/`). The `<normalized-cwd>` is computed by `normalizeCwd()`: strips `os.homedir()` prefix, replaces `/` with `_`, uses `_home` if empty. Each adapter declares its own mount points via `persistMounts()`. Per-agent persistence includes: `<persist-root>/mise/` → `/home/harness/.local/share/mise` (tools/plugins, `MISE_DATA_DIR`), `<persist-root>/mise-state/` → `/home/harness/.local/state/mise` (trust settings, `MISE_STATE_DIR`), and `<persist-root>/npm/` → `/home/harness/.local/share/npm` (pi adapter only: extensions/skills installed via `npm install -g`, `NPM_CONFIG_PREFIX`). One-shot runs are implicitly ephemeral. A deprecation warning is emitted if an old `.harness/` directory exists in the CWD.
 
 **User skills:** By default, harness bind-mounts the host user's skills directories into the container so agents can discover and use custom skills. Two source directories are checked (only if they exist on the host):
 
@@ -88,7 +88,7 @@ E2E tests in `tests/e2e/cli.test.mjs` use a docker shim (a fake `docker` binary 
 - Image tag selection per agent
 - Security flags (`--cap-drop=ALL`, `--security-opt`, etc.)
 - Persistence vs ephemeral behavior (TTY detection, `--ephemeral`, `-p`)
-- Volume mount construction (file vs directory, adapter-specific mount points)
+- Volume mount construction (file vs directory, adapter-specific mount points, npm persistence)
 - `--env-file` forwarding across all adapters
 - `--model` handling (local vs env-file mode, `--provider ollama` injection)
 - Cloud/local mode (`HARNESS_CLOUD_MODE`, `--local` flag)

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,12 +97,13 @@ RUN set -eux && \
     echo "${EXPECTED}  /tini" | sha256sum --check --strict && \
     chmod +x /tini
 
-RUN mkdir -p /home/harness/.local /home/harness/.npm-global && \
-    chown harness:harness /home/harness/.local /home/harness/.npm-global
+RUN mkdir -p /home/harness/.local/share/npm /home/harness/.local/state /home/harness/.config && \
+    chown -R harness:harness /home/harness/.local /home/harness/.config
 
 # Let npm install -g work for the harness user (avoid root-owned /usr/lib/node_modules)
-ENV NPM_CONFIG_PREFIX=/home/harness/.npm-global
-ENV PATH=/home/harness/.npm-global/bin:$PATH
+# Using /home/harness/.local/share/npm so it can be persisted alongside mise via volume mounts
+ENV NPM_CONFIG_PREFIX=/home/harness/.local/share/npm
+ENV PATH=/home/harness/.local/share/npm/bin:$PATH
 
 USER harness
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ The cooldown applies to transitive dependencies too. Older packages install norm
 
 ## Persistence
 
-Interactive runs (no `-p` and no piped stdin) store persistence data at `$XDG_DATA_HOME/harness/<project>/<agent>/` (defaults to `~/.local/share/harness/`). The `<project>` segment is the working directory path with `/` replaced by `_` and the home prefix stripped. This lets agents resume sessions, skip database migrations on repeat runs, and retain memories across invocations. Per-agent `mise` tool data and trust settings are persisted at `<persist-root>/mise/` and `<persist-root>/mise-state/` respectively.
+Interactive runs (no `-p` and no piped stdin) store persistence data at `$XDG_DATA_HOME/harness/<project>/<agent>/` (defaults to `~/.local/share/harness/`). The `<project>` segment is the working directory path with `/` replaced by `_` and the home prefix stripped. This lets agents resume sessions, skip database migrations on repeat runs, and retain memories across invocations. Per-agent `mise` tool data and trust settings are persisted at `<persist-root>/mise/` and `<persist-root>/mise-state/` respectively. For the pi adapter, extensions/skills installed via `npm install -g` are persisted at `<persist-root>/npm/`, avoiding re-downloads on every boot.
 
 One-shot runs (`-p` or piped stdin) are implicitly ephemeral — no persistence data is created. Use `--ephemeral` to force-disable persistence on interactive runs.
 

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,8 @@
       ".pnpm-store/",
       ".harness/",
       "opencode/",
-      "pi/"
+      "pi/",
+      ".pi-lens/"
     ]
   },
   "linter": {

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -66,7 +66,10 @@ class PiAdapter implements AgentAdapter {
   }
 
   persistMounts(): PersistMount[] {
-    return [{ hostSubpath: "", containerPath: "/home/harness/.pi/agent" }];
+    return [
+      { hostSubpath: "", containerPath: "/home/harness/.pi/agent" },
+      { hostSubpath: "npm", containerPath: "/home/harness/.local/share/npm" },
+    ];
   }
 }
 

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -2151,6 +2151,17 @@ test("interactive mode creates mise dir and mounts it at /home/harness/.local/sh
       a.some((arg) => arg.endsWith(":/home/harness/.local/state/mise")),
       `expected mise state volume mount in: ${a.join(" ")}`,
     );
+    // Verify npm dir on host
+    const npmDir = path.join(xdgData, "harness", nCwd, "pi", "npm");
+    assert.equal(
+      fs.existsSync(npmDir),
+      true,
+      `npm dir should exist at ${npmDir}`,
+    );
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/home/harness/.local/share/npm")),
+      `expected npm volume mount in: ${a.join(" ")}`,
+    );
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }
@@ -2191,6 +2202,11 @@ test("ephemeral mode (-p) does NOT create mise dir or mount", () => {
       a.some((arg) => arg.endsWith(":/home/harness/.local/state/mise")),
       false,
       "ephemeral mode must not mount mise state",
+    );
+    assert.equal(
+      a.some((arg) => arg.endsWith(":/home/harness/.local/share/npm")),
+      false,
+      "ephemeral mode must not mount npm",
     );
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
 Problem: Pi's package-manager checks for updates to configured packages (pi-lens, rpiv-ask-user-question, rpiv-todo) on every boot. Since
 NPM_CONFIG_PREFIX=/home/harness/.npm-global lives in the container image layer (not persisted), pi re-downloads and reinstalls all ~530+ npm packages every
 session, taking ~30s+.

 Fix — 3 changes:

 1. Dockerfile — Changed NPM_CONFIG_PREFIX from /home/harness/.npm-global to /home/harness/.local/share/npm, updated PATH accordingly, and adjusted the
 mkdir/chown to create the new directory.
 2. src/harness.ts — Added a new volume mount <persist-root>/npm/ → /home/harness/.local/share/npm alongside the existing mise mounts. This persists npm
 global packages across container restarts.
 3. tests/e2e/cli.test.mjs — Added assertions to the mise persistence test verifying the npm dir is created on host and mounted in docker args, and
 assertions to the ephemeral test verifying npm is NOT mounted in ephemeral mode.