### PR TITLE
docs: add Zensical documentation website with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install zensical
+      - run: pip install uv
+      - run: uv pip install --system zensical
       - run: zensical build --clean
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+name: Deploy Docs
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "zensical.toml"
+      - ".github/workflows/docs.yml"
+      - "README.md"
+      - "AGENTS.md"
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  allow-cancel-in-progress: false
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/configure-pages@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install zensical
+      - run: zensical build --clean
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+      - uses: actions/deploy-pages@v5
+        id: deployment

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/configure-pages@v6
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6.0.2
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: uv add zensical==0.0.43
       - run: zensical build --clean
       - uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,11 +26,8 @@ jobs:
     steps:
       - uses: actions/configure-pages@v6
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - run: pip install uv
-      - run: uv pip install --system zensical
+      - uses: astral-sh/setup-uv@v6
+      - run: uv add zensical==0.0.43
       - run: zensical build --clean
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ permissions:
   id-token: write
 concurrency:
   group: pages
-  allow-cancel-in-progress: false
+  cancel-in-progress: false
 jobs:
   deploy:
     environment:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 
 **Harness** is a portable containerized environment for running coding agents. See README.md for more project details.
 
+**Documentation website:** Built with [Zensical](https://zensical.org) from `docs/`. Config in `zensical.toml`. Deploys to GitHub Pages via `.github/workflows/docs.yml`. Build locally with `pip install zensical && zensical build --clean`.
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 Harness conveniently wraps Docker around three open-source coding agents — [`pi`](https://pi.dev/), [`opencode`](https://opencode.ai),
 and [`hermes`](https://github.com/NousResearch/hermes-agent) — so you can point one at a directory (or file) without giving it access to your entire machine.
 
+> **Documentation:** [capotej.github.io/harness](https://capotej.github.io/harness/)
+
 ## Features
 
 - **Sandboxed by default** — capability-dropped container with `no-new-privileges`; the agent only sees the directory (or file) you mount.

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -1,0 +1,36 @@
+---
+icon: lucide/bot
+---
+
+# hermes
+
+[`hermes`](https://github.com/NousResearch/hermes-agent) by NousResearch is a full-featured agent supporting many providers. It is the recommended choice for long-running "claw" deployments.
+
+## Local mode
+
+```bash
+npx @capotej/harness -a hermes -p "add tests"
+```
+
+LM Studio context length should be at least 64k tokens.
+
+## Cloud mode
+
+Pass `--env-file` to enter cloud mode — the agent auto-detects the provider from env vars.
+
+```bash
+echo "ANTHROPIC_API_KEY=sk-ant-***" > .env
+npx @capotej/harness -a hermes -e .env -p "add tests"
+npx @capotej/harness -a hermes -e .env -m openrouter/auto -p "add tests"
+```
+
+Common keys: `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`. [See full list](https://github.com/NousResearch/hermes-agent/blob/main/.env.example).
+
+The `-m` flag takes `provider/model` format.
+
+## Deploying as a claw
+
+Hermes can be deployed as a long-running persistent agent ("claw") reachable over a messaging gateway like Telegram. See the deployment guides:
+
+- [fly.io](../deploying/fly.md)
+- [Kubernetes](../deploying/k8s.md)

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -1,0 +1,43 @@
+---
+icon: lucide/terminal
+---
+
+# opencode
+
+[`opencode`](https://opencode.ai) defaults to LM Studio in local mode. Pass `--env-file` to enter cloud mode — the agent auto-detects the provider from whichever API key is in the file.
+
+## Local mode
+
+```bash
+npx @capotej/harness -a opencode -p "write a fizzbuzz in Go"
+```
+
+When using LM Studio locally, set the model's context length to at least 32k tokens.
+
+## Cloud mode
+
+The entrypoint detects the provider from your env file. Priority order: Anthropic > OpenAI > Google > ZAI > OpenRouter.
+
+```bash
+echo "OPENROUTER_API_KEY=sk-or-***" > .env
+npx @capotej/harness -a opencode -e .env -p "refactor the auth module"
+npx @capotej/harness -a opencode -e .env -m anthropic/claude-sonnet-4-5 -p "add tests"
+```
+
+Supported keys:
+
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+- `GOOGLE_API_KEY`
+- `ZAI_API_KEY`
+- `OPENROUTER_API_KEY`
+
+The `-m` flag takes a bare model name; the provider prefix is added automatically.
+
+## Force local mode
+
+To pass env vars but stay in local mode:
+
+```bash
+npx @capotej/harness -a opencode -e .env --local -p "refactor the auth module"
+```

--- a/docs/agents/pi.md
+++ b/docs/agents/pi.md
@@ -1,0 +1,54 @@
+---
+icon: lucide/cpu
+---
+
+# pi (default agent)
+
+[`pi`](https://pi.dev/) is the default agent. It supports many cloud providers and works with LM Studio locally.
+
+## Local mode
+
+Pi defaults to LM Studio with `google/gemma-4-e4b` (16k context is sufficient):
+
+```bash
+npx @capotej/harness -p "write a fizzbuzz in Go"
+```
+
+You can specify a different local model with `-m`. HuggingFace-style names with slashes work correctly:
+
+```bash
+npx @capotej/harness -m "qwen/qwen3.5-9b" -p "write a fizzbuzz in Go"
+```
+
+## Cloud mode
+
+Pass an `--env-file` containing any supported API key:
+
+| Provider      | Environment Variable |
+|---------------|----------------------|
+| Anthropic     | `ANTHROPIC_API_KEY`  |
+| OpenRouter    | `OPENROUTER_API_KEY` |
+| OpenAI        | `OPENAI_API_KEY`     |
+| Google Gemini | `GEMINI_API_KEY`     |
+| Mistral       | `MISTRAL_API_KEY`    |
+| Groq          | `GROQ_API_KEY`       |
+| Cerebras      | `CEREBRAS_API_KEY`   |
+| xAI           | `XAI_API_KEY`        |
+| Hugging Face  | `HF_TOKEN`           |
+
+See the [full provider list](https://github.com/badlogic/pi-mono/blob/c779c14e91bc2ea65143e59b0dc1baf3646ba8c9/packages/coding-agent/docs/providers.md#api-keys) for more options.
+
+## Examples
+
+```bash
+# One-shot prompt
+npx @capotej/harness -p "add a login endpoint"
+
+# With a specific model
+npx @capotej/harness -m anthropic/claude-sonnet-4-5 -p "refactor auth"
+
+# Interactive session (no -p)
+npx @capotej/harness
+```
+
+The `-m` flag is passed directly to pi as `--model`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,50 @@
+---
+icon: lucide/settings
+---
+
+# Configuration
+
+## CLI flags
+
+| Flag          | Alias | Description |
+|---------------|-------|-------------|
+| `--prompt`    | `-p`  | Pass a prompt directly to the agent |
+| `--env-file`  | `-e`  | Load environment variables into the container |
+| `--file`      | `-f`  | Mount a single file instead of the current directory |
+| `--model`     | `-m`  | Override the model used by the agent |
+| `--agent`     | `-a`  | Select agent: `pi`, `opencode`, `hermes` (default: `pi`) |
+| `--volumes`   | `-v`  | Additional volume mount (`host:container[:opts]`); may be repeated |
+| `--no-verify` |       | Skip cosign signature and provenance verification |
+| `--no-skills` |       | Disable mounting user skills directories |
+| `--ephemeral` |       | Disable session persistence (implied by `-p` and piped stdin) |
+| `--local`     |       | Force local mode even with `-e` (use LM Studio / local defaults) |
+| `--help`      | `-h`  | Show help |
+
+## Environment variables
+
+| Variable             | Description |
+|----------------------|-------------|
+| `HARNESS_IMAGE_TAG`  | Override the Docker image tag (defaults to the package version). Setting this implies `--no-verify`. |
+| `XDG_DATA_HOME`      | Override the base directory for persistence data (defaults to `~/.local/share`). |
+| `XDG_CACHE_HOME`     | Override the base directory for cosign cache (defaults to `~/.cache`). |
+
+## Agent-specific behavior
+
+### pi
+
+- `-m` is passed straight to the binary as `--model`
+- Without `-e`, passes `--provider ollama` so pi routes to LM Studio
+
+### opencode
+
+- `-m` is passed via the `OPENCODE_MODEL` env var
+- Without `-e`, uses LM Studio locally
+- With `-e`, enters cloud mode and auto-detects the provider from env vars
+- Use `--local` to force local mode even with `-e`
+
+### hermes
+
+- `-m` is passed as `--model` in `provider/model` form
+- Without `-e`, uses local config
+- With `-e`, enters cloud mode and auto-detects from env vars
+- Use `--local` to force local mode even with `-e`

--- a/docs/deploying/fly.md
+++ b/docs/deploying/fly.md
@@ -1,0 +1,102 @@
+# Deploying hermes as a fly.io "claw"
+
+You can deploy `hermes` as a long-running "claw" on [fly.io](https://fly.io), reachable over a messaging gateway. These instructions assume Telegram; adapt for other [messaging gateways](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
+
+Install and authenticate `flyctl`:
+
+```bash
+brew install flyctl
+fly auth login
+```
+
+Create `fly.toml`:
+
+```toml
+app = "my-hermes-agent-claw"
+primary_region = "iad"
+
+[env]
+  TZ = "America/New_York"
+  # Persist the faster-whisper model cache across restarts.
+  # Without this, the model re-downloads (~142 MB) on every deploy.
+  HF_HOME = "/home/harness/.hermes-openrouter/.cache/huggingface"
+
+[build]
+  image = "ghcr.io/capotej/harness:hermes-1.8.0"
+
+[processes]
+  app = "hermes gateway"
+
+[[mounts]]
+  source = "my_hermes_agent_claw_data"
+  destination = "/home/harness/.hermes-openrouter"
+  initial_size = "1gb"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+
+[[restart]]
+  policy = "always"
+  max_retries = 3
+```
+
+Create the app, volume, and secrets, then deploy:
+
+```bash
+fly apps create my-hermes-agent-claw
+fly volumes create my_hermes_agent_claw_data --region iad --size 1 --app my-hermes-agent-claw
+fly secrets set OPENROUTER_API_KEY=<your-key> --app my-hermes-agent-claw
+# https://hermes-agent.nousresearch.com/docs/user-guide/messaging/telegram#option-b-manual-configuration
+fly secrets set TELEGRAM_BOT_TOKEN=<your-token> --app my-hermes-agent-claw
+fly secrets set TELEGRAM_ALLOWED_USERS=<your-user-ids> --app my-hermes-agent-claw
+fly secrets set GH_TOKEN=<your-personal-access-token> --app my-hermes-agent-claw
+fly deploy --app my-hermes-agent-claw
+```
+
+> **GitHub CLI access:** The `GH_TOKEN` secret makes the `gh` CLI available inside the container. Tell the agent to add `terminal.env_passthrough: [GH_TOKEN]` to its `config.yaml` so the token is accessible in the sandbox.
+
+Message the bot via Telegram, or wire it up to a scheduled workflow — see the [daily briefing bot guide](https://hermes-agent.nousresearch.com/docs/guides/daily-briefing-bot) for an example.
+
+## Customizing the claw — *don't* extend the image
+
+When you want to give the claw extra capabilities (tool wrappers around your APIs, an opinionated initial system prompt, custom `gh`-style scripts), the temptation is to write a `Dockerfile` that does `FROM ghcr.io/capotej/harness:hermes-1.8.0` and bakes everything in. **Don't.** Two problems:
+
+1. The fly volume mounts on top of `/home/harness/.hermes-openrouter`, which silently hides anything you `COPY` into that path on first boot.
+2. Hermes treats `config.yaml` as mutable state — TUI tweaks, model switches, and persona toggles are persisted via `save_config()`. A derived image fights that ownership.
+
+The supported pattern is to use the upstream image **unmodified** and inject your customizations via fly's [`[[files]]`](https://fly.io/docs/reference/configuration/#the-files-section) section. Files at non-volume paths get refreshed on every deploy; files seeded into `/etc/harness/hermes-defaults/openrouter/` get copied into the volume on first boot only (via `entrypoint-hermes.sh`'s `cp -rn`) so hermes' subsequent runtime config edits stick across restarts.
+
+Example — add a `crm` API wrapper script and an initial system prompt without building a new image:
+
+```toml
+# fly.toml — append to the example above
+
+# Tool wrappers — written to a non-volume path. Refreshed on every deploy.
+# fly [[files]] preserves the local file's exec bit, so your scripts run
+# as-is from the agent's sandbox.
+[[files]]
+  guest_path = "/etc/myclaw/bin/crm"
+  local_path = "bin/crm"
+
+# Initial config + persona. Upstream's hermes entrypoint copies these into
+# the volume on first boot only — after that, hermes owns its config.
+[[files]]
+  guest_path = "/etc/harness/hermes-defaults/openrouter/system-prompt.md"
+  local_path = "config/system-prompt.md"
+```
+
+To force a refresh of `config.yaml` or `system-prompt.md` from your repo after the first boot, SSH in and delete the volume's copy before redeploying:
+
+```bash
+fly ssh console --app my-hermes-agent-claw \
+  -C 'rm /home/harness/.hermes-openrouter/system-prompt.md'
+fly deploy --app my-hermes-agent-claw
+```
+
+The benefits over a derived image:
+
+- **Faster deploys** — no rebuild, just pull the upstream image and apply files. Seconds instead of minutes.
+- **Trivial upstream upgrades** — bump one tag in `fly.toml`.
+- **No fight with hermes** over `config.yaml` ownership.
+- **One fewer artifact** to maintain, sign, and verify.

--- a/docs/deploying/k8s.md
+++ b/docs/deploying/k8s.md
@@ -1,0 +1,203 @@
+# Deploying `hermes-agent` to Kubernetes
+
+## Overview
+
+This guide walks you through deploying [hermes-agent](https://hermes-agent.nousresearch.com/) as a
+long-running "claw" (a persistent agent process) to a K8s cluster using the harness image.
+
+## Architecture
+
+| Component | Description |
+|---|---|
+| **Deployment** | Single-replica pod running `ghcr.io/capotej/harness:hermes-1.8.0` |
+| **PVC** | 100Gi persistent volume for agent data (`/home/harness/.hermes-openrouter`) |
+| **PDB** | PodDisruptionBudget ensuring at least 1 pod is available |
+| **Secrets** | API keys sourced from a K8s Secret (`k8sclaw-secrets`) |
+
+## Prerequisites
+
+- A Kubernetes cluster ≥ 1.21 (k3s or any compatible runtime)
+- `kubectl` installed and configured with cluster access
+- Container image access to `ghcr.io/capotej/harness:hermes-1.8.0`
+- A default StorageClass provisioned (or specify one in `k8sclaw.yaml`)
+
+## Deploy
+
+### 1. Create the namespace
+
+```bash
+kubectl create namespace k8sclaw
+```
+
+### 2. Create the Secret
+
+Create `k8sclaw-secrets` with the required keys:
+
+| Key | Description |
+|---|---|
+| `OPENROUTER_API_KEY` | API key for the OpenRouter LLM gateway |
+| `TELEGRAM_BOT_TOKEN` | Token for the Telegram bot interface |
+| `TELEGRAM_ALLOWED_USERS` | Comma-separated Telegram user IDs allowed to interact with the bot |
+| `GH_TOKEN` | GitHub personal access token for API access (e.g., PR management) |
+
+_If you add a <space> before the following command it won't end up in your shell history._
+
+```bash
+  kubectl --namespace k8sclaw create secret generic k8sclaw-secrets \
+  --from-literal=OPENROUTER_API_KEY="your-openrouter-key" \
+  --from-literal=TELEGRAM_BOT_TOKEN="your-telegram-token" \
+  --from-literal=TELEGRAM_ALLOWED_USERS="your-telegram-user-ids" \
+  --from-literal=GH_TOKEN="your-github-token"
+```
+
+### 3. Apply the manifests
+
+```bash
+kubectl apply -f k8sclaw.yaml
+```
+
+## Manifest Reference
+
+### All-in-one (`k8sclaw.yaml`)
+
+```yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: k8sclaw-data
+  namespace: k8sclaw
+spec:
+  # Uncomment and set to your cluster's StorageClass if no default is provisioned
+  # storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8sclaw
+  namespace: k8sclaw
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8sclaw
+  template:
+    metadata:
+      labels:
+        app: k8sclaw
+    spec:
+      terminationGracePeriodSeconds: 60
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: k8sclaw
+          image: ghcr.io/capotej/harness:hermes-1.8.0
+          imagePullPolicy: Always
+          command: ["/tini", "--", "hermes", "gateway"]
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
+          env:
+            - name: TZ
+              value: "America/New_York"
+            - name: HERMES_HOME
+              value: "/home/harness/.hermes-openrouter"
+            # Persist the faster-whisper model cache across restarts.
+            # Without this, the model re-downloads (~142 MB) on every pod restart.
+            - name: HF_HOME
+              value: "/home/harness/.hermes-openrouter/.cache/huggingface"
+            #
+            # add/modify any environment variables here
+            #  https://hermes-agent.nousresearch.com/docs/reference/environment-variables
+            #
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: k8sclaw-secrets
+                  key: OPENROUTER_API_KEY
+            - name: TELEGRAM_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: k8sclaw-secrets
+                  key: TELEGRAM_BOT_TOKEN
+            - name: TELEGRAM_ALLOWED_USERS
+              valueFrom:
+                secretKeyRef:
+                  name: k8sclaw-secrets
+                  key: TELEGRAM_ALLOWED_USERS
+            - name: GH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: k8sclaw-secrets
+                  key: GH_TOKEN
+          volumeMounts:
+            - name: data
+              mountPath: /home/harness/.hermes-openrouter
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1000m"
+            limits:
+              memory: "4Gi"
+              cpu: "4000m"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: k8sclaw-data
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: k8sclaw-pdb
+  namespace: k8sclaw
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: k8sclaw
+```
+
+> **Note:** The PDB prevents voluntary disruptions (e.g., `kubectl drain`) since there is only one replica. Remove the PDB from the manifest if you need to drain nodes.
+
+## Monitoring
+
+```bash
+# Check pod status
+kubectl --namespace k8sclaw get pods
+
+# Follow logs
+kubectl --namespace k8sclaw logs -l app=k8sclaw --tail=100 -f
+
+# Describe pod (for troubleshooting)
+kubectl --namespace k8sclaw describe pod -l app=k8sclaw
+
+# Resource usage (requires metrics-server)
+kubectl --namespace k8sclaw top pod -l app=k8sclaw
+```
+
+## Teardown
+
+```bash
+kubectl delete namespace k8sclaw
+```
+
+> This removes all resources in the namespace (Deployment, PVC, Secrets, PDB).
+
+## Customization
+
+| What to change | Where |
+|---|---|
+| Image tag | `k8sclaw.yaml` → Deployment → `image` |
+| Storage size | `k8sclaw.yaml` → PVC → `spec.resources.requests.storage` |
+| StorageClass | `k8sclaw.yaml` → PVC → `spec.storageClassName` |
+| Resource limits | `k8sclaw.yaml` → Deployment → `resources.requests/limits` |
+| Timezone | `k8sclaw.yaml` → Deployment → `env TZ` |
+| API keys / tokens | Update the `k8sclaw-secrets` Secret |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,90 @@
+---
+icon: lucide/rocket
+---
+
+# Getting Started
+
+## Prerequisites
+
+- [Docker](https://www.docker.com/) installed and running
+- For local mode: [LM Studio](https://lmstudio.ai/) with a model loaded
+
+## Installation
+
+No installation required. Run directly with `npx`:
+
+```bash
+npx @capotej/harness
+```
+
+Or install globally:
+
+```bash
+npm install -g @capotej/harness
+# or
+pnpm add -g @capotej/harness
+# or
+bun add -g @capotej/harness
+```
+
+## Local mode (LM Studio)
+
+Start LM Studio and load a model:
+
+```bash
+lms daemon up
+lms get google/gemma-4-e4b
+```
+
+Run harness:
+
+```bash
+npx @capotej/harness -p "write a fizzbuzz in Go"
+```
+
+### Interactive sessions
+
+Run without `-p` for an interactive session — agent state persists across runs:
+
+```bash
+npx @capotej/harness
+```
+
+### Pipe input
+
+```bash
+echo "write me a fizzbuzz in Go" | npx @capotej/harness
+```
+
+## Cloud mode
+
+Pass an `--env-file` containing your API key to use a cloud provider:
+
+```bash
+echo "ANTHROPIC_API_KEY=sk-ant-***" > .env
+npx @capotej/harness -e .env -p "add a login endpoint"
+```
+
+To pass env vars but stay in local mode, use `--local`:
+
+```bash
+npx @capotej/harness -e .env --local -p "refactor the auth module"
+```
+
+## Common flags
+
+```bash
+# Choose an agent
+npx @capotej/harness -a opencode -p "write tests"
+
+# Override the model
+npx @capotej/harness -m anthropic/claude-sonnet-4-5 -p "refactor auth"
+
+# Mount a single file instead of the directory
+npx @capotej/harness -f ./script.py -p "add type hints"
+
+# Skip image verification
+npx @capotej/harness --no-verify -p "quick task"
+```
+
+See the full reference at [Configuration](configuration.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,51 @@
+---
+icon: lucide/box
+---
+
+# Harness
+
+**Run agents in a sandboxed container — ready to drop into any project.**
+
+Harness wraps Docker around three open-source coding agents —
+[pi](https://pi.dev/), [opencode](https://opencode.ai), and
+[hermes](https://github.com/NousResearch/hermes-agent) — so you can point
+one at a directory (or file) without giving it access to your entire machine.
+
+## Why Harness?
+
+- **Sandboxed by default** — capability-dropped container with `no-new-privileges`;
+  the agent only sees the directory you mount.
+- **Three agents, one CLI** — switch between `pi`, `opencode`, and `hermes` with
+  `-a`. Same flags, same flow.
+- **Supply-chain hardened** — images are signed and verified with cosign and SLSA
+  provenance on every run; dependencies are pinned and verified.
+- **Local-first** — defaults to LM Studio with `gemma-4-e4b`. Drop in an
+  `--env-file` to use Anthropic, OpenRouter, OpenAI, Gemini, and others.
+- **Stateful or one-shot** — interactive runs persist agent state; one-shot
+  prompts stay ephemeral.
+- **Zero install** — `npx @capotej/harness` just works.
+
+## Quick start
+
+Docker is required. By default, harness uses LM Studio locally:
+
+```bash
+lms daemon up
+lms get google/gemma-4-e4b
+```
+
+Then run:
+
+```bash
+npx @capotej/harness -p "write a fizzbuzz in Go"
+```
+
+See the [Getting Started](getting-started.md) guide for more details.
+
+## Choose an agent
+
+| Agent | Description | Best for |
+|-------|-------------|----------|
+| [pi](agents/pi.md) | Default agent from [pi.dev](https://pi.dev/) | General-purpose coding |
+| [opencode](agents/opencode.md) | Terminal-based agent from [opencode.ai](https://opencode.ai) | Quick one-off tasks |
+| [hermes](agents/hermes.md) | Full-featured agent from [NousResearch](https://github.com/NousResearch/hermes-agent) | Long-running "claw" deployments |

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,44 @@
+---
+icon: lucide/hard-drive
+---
+
+# Persistence
+
+## How it works
+
+Interactive runs (no `-p` and no piped stdin) store persistence data at:
+
+```text
+$XDG_DATA_HOME/harness/<project>/<agent>/
+```
+
+Defaults to `~/.local/share/harness/`. The `<project>` segment is the working
+directory path with `/` replaced by `_` and the home prefix stripped.
+
+This lets agents resume sessions, skip database migrations on repeat runs, and
+retain memories across invocations.
+
+## One-shot vs interactive
+
+- **One-shot** (`-p` or piped stdin) — implicitly ephemeral, no persistence data
+  is created
+- **Interactive** (no `-p`, no piped stdin) — state persists automatically
+
+Use `--ephemeral` to force-disable persistence on interactive runs.
+
+## Per-agent persistence
+
+Each adapter declares its own mount points:
+
+- **pi** — `/home/harness/.pi/agent`
+- **opencode** — config, share, and state directories
+- **hermes** — `/home/harness/.hermes`
+
+Per-agent [mise](https://mise.jdx.dev/) tool data and trust settings are
+persisted at `<persist-root>/mise/` and `<persist-root>/mise-state/`
+respectively.
+
+## Migration from old format
+
+If an old `.harness/` directory exists in your working directory, harness will
+emit a deprecation warning with migration instructions.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,47 @@
+---
+icon: lucide/shield-check
+---
+
+# Security
+
+Harness layers protections at runtime, image, and dependency level.
+
+## Sandbox
+
+Each run starts the container with:
+
+- `--cap-drop=ALL --cap-add=NET_RAW` — minimal capability set
+- `--security-opt no-new-privileges:true` — block privilege escalation
+- `--security-opt seccomp=...` — inline seccomp profile blocks `socket(AF_ALG)`
+  to prevent kernel crypto API access (a known container escape vector)
+- Only your mounted directory (or single file with `-f`) is visible to the agent
+
+## Image verification
+
+By default, harness verifies that the container image was signed by the official
+CI workflow and carries a valid SLSA provenance attestation. This requires
+[cosign](https://github.com/sigstore/cosign):
+
+```bash
+brew install cosign
+```
+
+Verified digests are cached at `~/.cache/harness/cosign-verified.json` so
+verification only runs once per image. Skip with `--no-verify` (or by setting
+`HARNESS_IMAGE_TAG`, which implies skip):
+
+```bash
+npx @capotej/harness --no-verify -p "write a fizzbuzz in Go"
+```
+
+## Dependency cooldown
+
+The image build enforces a 7-day cooldown on dependency resolution — a guard
+against supply-chain compromises that are typically discovered and yanked within
+hours.
+
+- **pnpm**: `PNPM_MINIMUM_RELEASE_AGE=10080` (minutes) via environment variable
+- **uv**: `--exclude-newer` set to 7 days ago at image build time
+
+The cooldown applies to transitive dependencies too. Older packages install
+normally.

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,96 @@
+[project]
+
+site_name = "Harness"
+site_description = "Run agents in a sandboxed container — ready to drop into any project."
+site_author = "Julio Capote"
+site_url = "https://capotej.github.io/harness/"
+
+copyright = """
+Copyright &copy; 2025 Julio Capote
+"""
+
+nav = [
+  { "Home" = "docs/index.md" },
+  { "Getting Started" = "docs/getting-started.md" },
+  { "Agents" = [
+    { "pi" = "docs/agents/pi.md" },
+    { "opencode" = "docs/agents/opencode.md" },
+    { "hermes" = "docs/agents/hermes.md" },
+  ]},
+  { "Deploying" = [
+    { "fly.io" = "docs/deploying/fly.md" },
+    { "Kubernetes" = "docs/deploying/k8s.md" },
+  ]},
+  { "Configuration" = "docs/configuration.md" },
+  { "Security" = "docs/security.md" },
+  { "Persistence" = "docs/persistence.md" },
+]
+
+[project.theme]
+
+language = "en"
+
+features = [
+  "announce.dismiss",
+  "content.code.annotate",
+  "content.code.copy",
+  "content.code.select",
+  "content.footnote.tooltips",
+  "content.tabs.link",
+  "content.tooltips",
+  "navigation.footer",
+  "navigation.indexes",
+  "navigation.instant",
+  "navigation.instant.prefetch",
+  "navigation.path",
+  "navigation.sections",
+  "navigation.top",
+  "navigation.tracking",
+  "search.highlight",
+]
+
+[[project.theme.palette]]
+scheme = "default"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+scheme = "slate"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to light mode"
+
+[project.markdown_extensions.abbr]
+[project.markdown_extensions.admonition]
+[project.markdown_extensions.attr_list]
+[project.markdown_extensions.def_list]
+[project.markdown_extensions.footnotes]
+[project.markdown_extensions.md_in_html]
+[project.markdown_extensions.toc]
+permalink = true
+[project.markdown_extensions.pymdownx.arithmatex]
+generic = true
+[project.markdown_extensions.pymdownx.betterem]
+[project.markdown_extensions.pymdownx.caret]
+[project.markdown_extensions.pymdownx.details]
+[project.markdown_extensions.pymdownx.emoji]
+emoji_generator = "zensical.extensions.emoji.to_svg"
+emoji_index = "zensical.extensions.emoji.twemoji"
+[project.markdown_extensions.pymdownx.highlight]
+anchor_linenums = true
+line_spans = "__span"
+pygments_lang_class = true
+[project.markdown_extensions.pymdownx.inlinehilite]
+[project.markdown_extensions.pymdownx.keys]
+[project.markdown_extensions.pymdownx.magiclink]
+[project.markdown_extensions.pymdownx.mark]
+[project.markdown_extensions.pymdownx.smartsymbols]
+[project.markdown_extensions.pymdownx.superfences]
+custom_fences = [
+  { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" }
+]
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+combine_header_slug = true
+[project.markdown_extensions.pymdownx.tasklist]
+custom_checkbox = true
+[project.markdown_extensions.pymdownx.tilde]


### PR DESCRIPTION
## Summary

Adds a public documentation website built with [Zensical](https://zensical.org) and deployed to GitHub Pages via GitHub Actions.

**Site:** https://capotej.github.io/harness/

## What's new

- **`zensical.toml`** — site config with explicit navigation, dark/light theme, search, and markdown extensions
- **`.github/workflows/docs.yml`** — deploys to GitHub Pages on push to `main` (only when docs files change)
- **8 new content pages:**
  - `docs/index.md` — landing page with features and agent comparison
  - `docs/getting-started.md` — quickstart guide (local + cloud mode)
  - `docs/agents/pi.md` — pi agent docs with provider table
  - `docs/agents/opencode.md` — opencode agent docs with provider priority
  - `docs/agents/hermes.md` — hermes agent docs with claw deployment links
  - `docs/configuration.md` — CLI flags and env vars reference
  - `docs/security.md` — sandbox, cosign, dependency cooldown
  - `docs/persistence.md` — XDG layout, per-agent mounts
- **2 deployment guides** copied into `docs/deploying/` (originals kept at `docs/deploying-to-*.md` for backward compat)
- **README.md** — added docs site link
- **AGENTS.md** — noted docs website for future agents

## Implementation notes

- Existing `docs/deploying-to-fly.md` and `docs/deploying-to-k8s.md` are unchanged (README links to them)
- No changes to CLI, Dockerfiles, or test infrastructure
- RFC reference: `rfcs/2025-05-24_documentation_website.md`

## Verification

- `zensical build --clean` — 13 HTML pages, no errors
- `pnpm lint:md` — no lint errors in docs files
- `pnpm test:e2e` — 78/78 pass, no regressions

## Setup required

After merge, enable GitHub Pages in repo settings:
1. Settings → Pages
2. Source: **GitHub Actions**