### PR TITLE
docs: mark documentation website RFC as Implemented

### DIFF
--- a/rfcs/2025-05-24_documentation_website.md
+++ b/rfcs/2025-05-24_documentation_website.md
@@ -1,7 +1,7 @@
 # Documentation Website: Zensical + GitHub Pages
 
 **Date:** 2025-05-24
-**Status:** Proposed
+**Status:** Implemented
 
 ## Goal
 


### PR DESCRIPTION
## Summary

Updates the RFC status to `Implemented` since the docs site is now live.

## Note

The GitHub Pages settings currently have a custom domain (`capotej.com/harness`) that causes a redirect. The `site_url` in `zensical.toml` and all docs links already point to `https://capotej.github.io/harness/`. You'll need to clear the custom domain in repo settings (Settings → Pages → Custom domain → remove) for the default GitHub Pages URL to work correctly.