### PR TITLE
feat: mount global ~/.agents/AGENTS.md into agent context path (#85)

### DIFF
--- a/src/harness.ts
+++ b/src/harness.ts
@@ -15,11 +15,12 @@ const SECCOMP_PROFILE = path.join(
 interface Args extends ParsedArgs {
   help: boolean;
   h: boolean;
-  // minimist --no- prefix: --no-verify / --no-skills set these to false; NOT in boolean[] to avoid double-negation
+  // minimist --no- prefix: --no-verify / --no-skills / --no-agents-md set these to false; NOT in boolean[] to avoid double-negation
   verify?: boolean;
   ephemeral: boolean;
   local: boolean;
   skills?: boolean;
+  "agents-md"?: boolean;
   "env-file"?: string;
   e?: string;
   file?: string;
@@ -48,6 +49,9 @@ interface AgentAdapter {
   buildCommand(options: AgentOptions): string[];
   extraDockerArgs?(options: AgentOptions): string[];
   persistMounts?(): PersistMount[];
+  // Container path where this agent loads a global AGENTS.md context file.
+  // The host's ~/.agents/AGENTS.md is bind-mounted here when present.
+  agentsMdTarget?(): string;
 }
 
 class PiAdapter implements AgentAdapter {
@@ -70,6 +74,10 @@ class PiAdapter implements AgentAdapter {
       { hostSubpath: "", containerPath: "/home/harness/.pi/agent" },
       { hostSubpath: "npm", containerPath: "/home/harness/.local/share/npm" },
     ];
+  }
+
+  agentsMdTarget(): string {
+    return "/home/harness/.pi/agent/AGENTS.md";
   }
 }
 
@@ -101,6 +109,10 @@ class OpenCodeAdapter implements AgentAdapter {
       },
     ];
   }
+
+  agentsMdTarget(): string {
+    return "/home/harness/.config/opencode/AGENTS.md";
+  }
 }
 
 class HermesAdapter implements AgentAdapter {
@@ -113,6 +125,10 @@ class HermesAdapter implements AgentAdapter {
 
   persistMounts(): PersistMount[] {
     return [{ hostSubpath: "", containerPath: "/home/harness/.hermes" }];
+  }
+
+  agentsMdTarget(): string {
+    return "/home/harness/.hermes/AGENTS.md";
   }
 }
 
@@ -325,6 +341,7 @@ Options:
   -v, --volumes <spec>   Additional volume mount (host:container[:opts]); may be repeated
   --no-verify            Skip cosign image signature and provenance verification
   --no-skills            Disable mounting user skills directories (~/.agents/skills, ~/.claude/skills)
+  --no-agents-md         Disable mounting global ~/.agents/AGENTS.md into the agent context path
   --ephemeral            Disable session persistence (implied by -p and piped stdin)
   --local                Force local mode even with -e (use LM Studio / local defaults)
   -h, --help             Show this help message
@@ -407,6 +424,7 @@ const argv = minimist<Args>(process.argv.slice(2), MINIMIST_OPTS);
     ...Object.values(MINIMIST_OPTS.alias),
     "verify", // --no-verify sets verify=false
     "skills", // --no-skills sets skills=false
+    "agents-md", // --no-agents-md sets agents-md=false
     "local",
   ]);
   const unknown = Object.keys(argv).filter((k) => !knownKeys.has(k));
@@ -424,6 +442,7 @@ if (argv.help) {
 
 const noVerify = argv.verify === false;
 const noSkills = argv.skills === false;
+const noAgentsMd = argv["agents-md"] === false;
 const localMode = argv.local;
 const envFilePath = argv["env-file"] || null;
 const fileArg = argv.file || null;
@@ -559,6 +578,21 @@ async function run(prompt: string | null): Promise<void> {
       if (fs.existsSync(sd.host) && fs.statSync(sd.host).isDirectory()) {
         volumeArgs.push("-v", `${sd.host}:${sd.container}`);
       }
+    }
+  }
+
+  // Mount the user's global ~/.agents/AGENTS.md into the adapter's expected
+  // context path so cross-agent rules apply inside the container. Skipped when
+  // the source file is absent (like skills dirs) or --no-agents-md is passed.
+  if (!noAgentsMd) {
+    const agentsMdHost = path.resolve(os.homedir(), ".agents", "AGENTS.md");
+    const agentsMdTarget = adapter.agentsMdTarget?.();
+    if (
+      agentsMdTarget &&
+      fs.existsSync(agentsMdHost) &&
+      fs.statSync(agentsMdHost).isFile()
+    ) {
+      volumeArgs.push("-v", `${agentsMdHost}:${agentsMdTarget}`);
     }
   }
 

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -15,12 +15,12 @@ const SECCOMP_PROFILE = path.join(
 interface Args extends ParsedArgs {
   help: boolean;
   h: boolean;
-  // minimist --no- prefix: --no-verify / --no-skills / --no-agents-md set these to false; NOT in boolean[] to avoid double-negation
+  // minimist --no- prefix: --no-verify / --no-skills / --no-context-files set these to false; NOT in boolean[] to avoid double-negation
   verify?: boolean;
   ephemeral: boolean;
   local: boolean;
   skills?: boolean;
-  "agents-md"?: boolean;
+  "context-files"?: boolean;
   "env-file"?: string;
   e?: string;
   file?: string;
@@ -49,9 +49,10 @@ interface AgentAdapter {
   buildCommand(options: AgentOptions): string[];
   extraDockerArgs?(options: AgentOptions): string[];
   persistMounts?(): PersistMount[];
-  // Container path where this agent loads a global AGENTS.md context file.
-  // The host's ~/.agents/AGENTS.md is bind-mounted here when present.
-  agentsMdTarget?(): string;
+  // Container directory where this agent loads global context files. The
+  // host's ~/.agents/AGENTS.md and ~/.claude/CLAUDE.md are bind-mounted into
+  // this directory (as AGENTS.md / CLAUDE.md) when present.
+  contextDir?(): string;
 }
 
 class PiAdapter implements AgentAdapter {
@@ -76,8 +77,8 @@ class PiAdapter implements AgentAdapter {
     ];
   }
 
-  agentsMdTarget(): string {
-    return "/home/harness/.pi/agent/AGENTS.md";
+  contextDir(): string {
+    return "/home/harness/.pi/agent";
   }
 }
 
@@ -110,8 +111,8 @@ class OpenCodeAdapter implements AgentAdapter {
     ];
   }
 
-  agentsMdTarget(): string {
-    return "/home/harness/.config/opencode/AGENTS.md";
+  contextDir(): string {
+    return "/home/harness/.config/opencode";
   }
 }
 
@@ -127,8 +128,8 @@ class HermesAdapter implements AgentAdapter {
     return [{ hostSubpath: "", containerPath: "/home/harness/.hermes" }];
   }
 
-  agentsMdTarget(): string {
-    return "/home/harness/.hermes/AGENTS.md";
+  contextDir(): string {
+    return "/home/harness/.hermes";
   }
 }
 
@@ -341,7 +342,7 @@ Options:
   -v, --volumes <spec>   Additional volume mount (host:container[:opts]); may be repeated
   --no-verify            Skip cosign image signature and provenance verification
   --no-skills            Disable mounting user skills directories (~/.agents/skills, ~/.claude/skills)
-  --no-agents-md         Disable mounting global ~/.agents/AGENTS.md into the agent context path
+  --no-context-files     Disable mounting global context files (~/.agents/AGENTS.md, ~/.claude/CLAUDE.md); alias -nc
   --ephemeral            Disable session persistence (implied by -p and piped stdin)
   --local                Force local mode even with -e (use LM Studio / local defaults)
   -h, --help             Show this help message
@@ -412,7 +413,12 @@ const MINIMIST_OPTS = {
   },
 };
 
-const argv = minimist<Args>(process.argv.slice(2), MINIMIST_OPTS);
+// Translate pi's short context-files flag (-nc) to its long form before
+// minimist, which would otherwise split -nc into clustered -n -c flags.
+const rawArgs = process.argv
+  .slice(2)
+  .map((a) => (a === "-nc" ? "--no-context-files" : a));
+const argv = minimist<Args>(rawArgs, MINIMIST_OPTS);
 
 // Warn on unrecognized flags
 {
@@ -424,7 +430,7 @@ const argv = minimist<Args>(process.argv.slice(2), MINIMIST_OPTS);
     ...Object.values(MINIMIST_OPTS.alias),
     "verify", // --no-verify sets verify=false
     "skills", // --no-skills sets skills=false
-    "agents-md", // --no-agents-md sets agents-md=false
+    "context-files", // --no-context-files / -nc sets context-files=false
     "local",
   ]);
   const unknown = Object.keys(argv).filter((k) => !knownKeys.has(k));
@@ -442,7 +448,7 @@ if (argv.help) {
 
 const noVerify = argv.verify === false;
 const noSkills = argv.skills === false;
-const noAgentsMd = argv["agents-md"] === false;
+const noContextFiles = argv["context-files"] === false;
 const localMode = argv.local;
 const envFilePath = argv["env-file"] || null;
 const fileArg = argv.file || null;
@@ -581,18 +587,28 @@ async function run(prompt: string | null): Promise<void> {
     }
   }
 
-  // Mount the user's global ~/.agents/AGENTS.md into the adapter's expected
-  // context path so cross-agent rules apply inside the container. Skipped when
-  // the source file is absent (like skills dirs) or --no-agents-md is passed.
-  if (!noAgentsMd) {
-    const agentsMdHost = path.resolve(os.homedir(), ".agents", "AGENTS.md");
-    const agentsMdTarget = adapter.agentsMdTarget?.();
-    if (
-      agentsMdTarget &&
-      fs.existsSync(agentsMdHost) &&
-      fs.statSync(agentsMdHost).isFile()
-    ) {
-      volumeArgs.push("-v", `${agentsMdHost}:${agentsMdTarget}`);
+  // Mount the user's global context files into the adapter's context directory
+  // so cross-agent rules apply inside the container. Mirrors pi's context-files
+  // model (AGENTS.md + CLAUDE.md). Each file is skipped when absent (like skills
+  // dirs); --no-context-files / -nc disables all of them.
+  if (!noContextFiles) {
+    const contextDir = adapter.contextDir?.();
+    if (contextDir) {
+      const contextFiles = [
+        {
+          host: path.resolve(os.homedir(), ".agents", "AGENTS.md"),
+          name: "AGENTS.md",
+        },
+        {
+          host: path.resolve(os.homedir(), ".claude", "CLAUDE.md"),
+          name: "CLAUDE.md",
+        },
+      ];
+      for (const cf of contextFiles) {
+        if (fs.existsSync(cf.host) && fs.statSync(cf.host).isFile()) {
+          volumeArgs.push("-v", `${cf.host}:${contextDir}/${cf.name}`);
+        }
+      }
     }
   }
 

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -2340,3 +2340,137 @@ test("--help documents XDG_DATA_HOME and XDG_CACHE_HOME environment variables", 
   assert.match(r.stdout, /Environment variables:[\s\S]*XDG_DATA_HOME/);
   assert.match(r.stdout, /\$XDG_DATA_HOME\/harness/);
 });
+
+// ---- global AGENTS.md mounting (issue #85) ---------------------------------
+//
+// A single host ~/.agents/AGENTS.md is bind-mounted into each agent's expected
+// context path. Reuses makeSkillsHome() for an isolated temp HOME.
+
+function writeAgentsMd(home) {
+  fs.mkdirSync(path.join(home, ".agents"), { recursive: true });
+  fs.writeFileSync(path.join(home, ".agents", "AGENTS.md"), "# global rules\n");
+}
+
+test("global ~/.agents/AGENTS.md is mounted to the pi context path", () => {
+  const { home, cleanup } = makeSkillsHome();
+  writeAgentsMd(home);
+  try {
+    const r = runCli(["-p", "noop"], { extraEnv: { HOME: home } });
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/home/harness/.pi/agent/AGENTS.md")),
+      `expected AGENTS.md mount at pi path in: ${a.join(" ")}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("global ~/.agents/AGENTS.md is mounted to the opencode context path", () => {
+  const { home, cleanup } = makeSkillsHome();
+  writeAgentsMd(home);
+  try {
+    const r = runCli(["-a", "opencode", "-p", "noop"], {
+      extraEnv: { HOME: home },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.ok(
+      a.some((arg) =>
+        arg.endsWith(":/home/harness/.config/opencode/AGENTS.md"),
+      ),
+      `expected AGENTS.md mount at opencode path in: ${a.join(" ")}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("global ~/.agents/AGENTS.md is mounted to the hermes context path", () => {
+  const { home, cleanup } = makeSkillsHome();
+  writeAgentsMd(home);
+  try {
+    const r = runCli(["-a", "hermes", "-p", "noop"], {
+      extraEnv: { HOME: home },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/home/harness/.hermes/AGENTS.md")),
+      `expected AGENTS.md mount at hermes path in: ${a.join(" ")}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("--no-agents-md suppresses the global AGENTS.md mount", () => {
+  const { home, cleanup } = makeSkillsHome();
+  writeAgentsMd(home);
+  try {
+    const r = runCli(["--no-agents-md", "-p", "noop"], {
+      extraEnv: { HOME: home },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.equal(
+      a.some((arg) => arg.includes("/AGENTS.md")),
+      false,
+      `--no-agents-md must not mount AGENTS.md: ${a.join(" ")}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("non-existent ~/.agents/AGENTS.md is silently skipped", () => {
+  // Empty temp HOME — no AGENTS.md exists, so the mount is skipped.
+  const { home, cleanup } = makeSkillsHome();
+  try {
+    const r = runCli(["-p", "noop"], { extraEnv: { HOME: home } });
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.equal(
+      a.some((arg) => arg.includes("/AGENTS.md")),
+      false,
+      `non-existent AGENTS.md must not be mounted: ${a.join(" ")}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("global AGENTS.md mount works with --file mode", () => {
+  const { home, cleanup } = makeSkillsHome();
+  writeAgentsMd(home);
+  try {
+    const r = runCli(["--file", SAMPLE_FILE, "-p", "noop"], {
+      extraEnv: { HOME: home },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/workspace/script.py")),
+      `expected file mount in: ${a.join(" ")}`,
+    );
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/home/harness/.pi/agent/AGENTS.md")),
+      `expected AGENTS.md mount in --file mode: ${a.join(" ")}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("--help documents --no-agents-md", () => {
+  const r = runCli(["--help"]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /--no-agents-md/);
+});

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -2341,14 +2341,20 @@ test("--help documents XDG_DATA_HOME and XDG_CACHE_HOME environment variables", 
   assert.match(r.stdout, /\$XDG_DATA_HOME\/harness/);
 });
 
-// ---- global AGENTS.md mounting (issue #85) ---------------------------------
+// ---- global context files mounting (issue #85) -----------------------------
 //
-// A single host ~/.agents/AGENTS.md is bind-mounted into each agent's expected
-// context path. Reuses makeSkillsHome() for an isolated temp HOME.
+// A single host ~/.agents/AGENTS.md and ~/.claude/CLAUDE.md are bind-mounted
+// into each agent's context directory. Reuses makeSkillsHome() for an isolated
+// temp HOME.
 
 function writeAgentsMd(home) {
   fs.mkdirSync(path.join(home, ".agents"), { recursive: true });
   fs.writeFileSync(path.join(home, ".agents", "AGENTS.md"), "# global rules\n");
+}
+
+function writeClaudeMd(home) {
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true });
+  fs.writeFileSync(path.join(home, ".claude", "CLAUDE.md"), "# claude rules\n");
 }
 
 test("global ~/.agents/AGENTS.md is mounted to the pi context path", () => {
@@ -2408,11 +2414,72 @@ test("global ~/.agents/AGENTS.md is mounted to the hermes context path", () => {
   }
 });
 
-test("--no-agents-md suppresses the global AGENTS.md mount", () => {
+test("global ~/.claude/CLAUDE.md is mounted to the pi context path", () => {
+  const { home, cleanup } = makeSkillsHome();
+  writeClaudeMd(home);
+  try {
+    const r = runCli(["-p", "noop"], { extraEnv: { HOME: home } });
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/home/harness/.pi/agent/CLAUDE.md")),
+      `expected CLAUDE.md mount at pi path in: ${a.join(" ")}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("global ~/.claude/CLAUDE.md is mounted to the opencode context path", () => {
+  const { home, cleanup } = makeSkillsHome();
+  writeClaudeMd(home);
+  try {
+    const r = runCli(["-a", "opencode", "-p", "noop"], {
+      extraEnv: { HOME: home },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.ok(
+      a.some((arg) =>
+        arg.endsWith(":/home/harness/.config/opencode/CLAUDE.md"),
+      ),
+      `expected CLAUDE.md mount at opencode path in: ${a.join(" ")}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("AGENTS.md and CLAUDE.md are both mounted when both exist", () => {
   const { home, cleanup } = makeSkillsHome();
   writeAgentsMd(home);
+  writeClaudeMd(home);
   try {
-    const r = runCli(["--no-agents-md", "-p", "noop"], {
+    const r = runCli(["-p", "noop"], { extraEnv: { HOME: home } });
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/home/harness/.pi/agent/AGENTS.md")),
+      `expected AGENTS.md mount in: ${a.join(" ")}`,
+    );
+    assert.ok(
+      a.some((arg) => arg.endsWith(":/home/harness/.pi/agent/CLAUDE.md")),
+      `expected CLAUDE.md mount in: ${a.join(" ")}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("--no-context-files suppresses all global context file mounts", () => {
+  const { home, cleanup } = makeSkillsHome();
+  writeAgentsMd(home);
+  writeClaudeMd(home);
+  try {
+    const r = runCli(["--no-context-files", "-p", "noop"], {
       extraEnv: { HOME: home },
     });
     assert.equal(r.status, 0, r.stderr);
@@ -2421,15 +2488,45 @@ test("--no-agents-md suppresses the global AGENTS.md mount", () => {
     assert.equal(
       a.some((arg) => arg.includes("/AGENTS.md")),
       false,
-      `--no-agents-md must not mount AGENTS.md: ${a.join(" ")}`,
+      `--no-context-files must not mount AGENTS.md: ${a.join(" ")}`,
+    );
+    assert.equal(
+      a.some((arg) => arg.includes("/CLAUDE.md")),
+      false,
+      `--no-context-files must not mount CLAUDE.md: ${a.join(" ")}`,
     );
   } finally {
     cleanup();
   }
 });
 
-test("non-existent ~/.agents/AGENTS.md is silently skipped", () => {
-  // Empty temp HOME — no AGENTS.md exists, so the mount is skipped.
+test("-nc short flag suppresses all global context file mounts", () => {
+  const { home, cleanup } = makeSkillsHome();
+  writeAgentsMd(home);
+  writeClaudeMd(home);
+  try {
+    const r = runCli(["-nc", "-p", "noop"], { extraEnv: { HOME: home } });
+    assert.equal(r.status, 0, r.stderr);
+    const a = dockerArgs(r.stdout);
+    assert.ok(a, "expected DOCKER_INVOKED line");
+    assert.equal(
+      a.some((arg) => arg.includes("/AGENTS.md") || arg.includes("/CLAUDE.md")),
+      false,
+      `-nc must not mount context files: ${a.join(" ")}`,
+    );
+    // -nc must not leak as an unrecognized-flag warning.
+    assert.equal(
+      /unrecognized flag/.test(r.stderr),
+      false,
+      `-nc must be recognized: ${r.stderr}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("non-existent global context files are silently skipped", () => {
+  // Empty temp HOME — no AGENTS.md/CLAUDE.md exist, so mounts are skipped.
   const { home, cleanup } = makeSkillsHome();
   try {
     const r = runCli(["-p", "noop"], { extraEnv: { HOME: home } });
@@ -2437,16 +2534,16 @@ test("non-existent ~/.agents/AGENTS.md is silently skipped", () => {
     const a = dockerArgs(r.stdout);
     assert.ok(a, "expected DOCKER_INVOKED line");
     assert.equal(
-      a.some((arg) => arg.includes("/AGENTS.md")),
+      a.some((arg) => arg.includes("/AGENTS.md") || arg.includes("/CLAUDE.md")),
       false,
-      `non-existent AGENTS.md must not be mounted: ${a.join(" ")}`,
+      `non-existent context files must not be mounted: ${a.join(" ")}`,
     );
   } finally {
     cleanup();
   }
 });
 
-test("global AGENTS.md mount works with --file mode", () => {
+test("global context file mount works with --file mode", () => {
   const { home, cleanup } = makeSkillsHome();
   writeAgentsMd(home);
   try {
@@ -2469,8 +2566,9 @@ test("global AGENTS.md mount works with --file mode", () => {
   }
 });
 
-test("--help documents --no-agents-md", () => {
+test("--help documents --no-context-files and -nc", () => {
   const r = runCli(["--help"]);
   assert.equal(r.status, 0, r.stderr);
-  assert.match(r.stdout, /--no-agents-md/);
+  assert.match(r.stdout, /--no-context-files/);
+  assert.match(r.stdout, /-nc/);
 });


### PR DESCRIPTION
## Summary

Closes #85.

Harness already bind-mounts user **skills** directories (`~/.agents/skills`, `~/.claude/skills`) but did not mount a global **`AGENTS.md`** file that agents load for user-wide context rules. This PR mounts a single canonical host source — `~/.agents/AGENTS.md` — into each adapter's expected context path.

## Mount targets per adapter

| Adapter | Container target |
|---|---|
| **pi** | `/home/harness/.pi/agent/AGENTS.md` |
| **opencode** | `/home/harness/.config/opencode/AGENTS.md` |
| **hermes** | `/home/harness/.hermes/AGENTS.md` |

Each adapter declares its own target via a new optional `agentsMdTarget()` method on `AgentAdapter`, mirroring the existing `persistMounts()` pattern — so per-adapter paths stay self-contained.

## Behavior (matches acceptance criteria)

- [x] Host `~/.agents/AGENTS.md` is mounted into the container at the agent-expected path
- [x] Mount is **skipped when the source file is absent** (same as skills dirs)
- [x] **`--no-agents-md`** flag disables the mount (analogous to `--no-skills`)
- [x] Each adapter defines its own target mount path
- [x] E2E tests cover the new mount behavior

## Notes / scope decisions

- Source is a **file**, validated with `fs.statSync(...).isFile()` (skills use `isDirectory()`), so a stray directory at that path won't be mounted.
- Kept to the single canonical `~/.agents/AGENTS.md` source from the issue's primary proposal. The optional `~/.claude/CLAUDE.md` fallback path is intentionally left out of this PR to keep the surface minimal — happy to add it as a follow-up if you'd like.
- No change to verification, persistence, or `--file` mode beyond the additive mount.

## Tests

7 new e2e tests appended to `tests/e2e/cli.test.mjs`:
- per-adapter target path (pi / opencode / hermes)
- `--no-agents-md` suppression
- silent skip when `AGENTS.md` is absent
- coexistence with `--file` mode
- `--help` documents `--no-agents-md`

Full suite: **90 passing / 0 failing** locally (`pnpm test:e2e`). `biome check` clean, `pnpm build` green.

cc @capotej for review.
