### PR TITLE
feat: add openssh-client to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
         git \
         gnupg \
         jq \
+        openssh-client \
         ripgrep \
         sudo \
     && mkdir -p /etc/apt/keyrings \


### PR DESCRIPTION
## Summary

- Adds `openssh-client` to the base Docker image's `apt-get install` list

## Motivation

Agents running inside harness containers need SSH access for:
- Git push/pull via SSH (`git@github.com:...`)
- SSH-based workflows and remote connections

## Test Plan

- [x] `make image-base` builds successfully with the new package
- [ ] CI `pr-build` workflow passes
