### PR TITLE
fix: remove no-new-privileges to allow sudo apt/dpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and [`hermes`](https://github.com/NousResearch/hermes-agent) — so you can poin
 
 ## Features
 
-- **Sandboxed by default** — capability-dropped container with `no-new-privileges`; the agent only sees the directory (or file) you mount.
+- **Sandboxed by default** — capability-dropped container with seccomp hardening; the agent only sees the directory (or file) you mount.
 - **Three agents, one CLI** — switch between `pi`, `opencode`, and `hermes` with `-a`. Same flags, same flow.
 - **Supply-chain hardened** — the image is signed and verified with cosign and SLSA provenance on every run; dependencies installed inside the container are always pinned and verified where possible and a 7-day "cooldown" is used to mitigate supply-chain attacks.
 - **Local-first** — defaults to LM Studio with `gemma-4-e4b`. Drop in an `--env-file` to use Anthropic, OpenRouter, OpenAI, Gemini, and others.
@@ -185,7 +185,6 @@ Harness layers protections at runtime, image, and dependency level.
 Each run starts the container with:
 
 - `--cap-drop=ALL --cap-add=NET_RAW` — minimal capability set
-- `--security-opt no-new-privileges:true` — block privilege escalation
 - `--security-opt seccomp=...` — inline seccomp profile blocks `socket(AF_ALG)` to prevent kernel crypto API access (a known container escape vector)
 - Only your mounted directory (or single file with `-f`) is visible to the agent
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ one at a directory (or file) without giving it access to your entire machine.
 
 ## Why Harness?
 
-- **Sandboxed by default** — capability-dropped container with `no-new-privileges`;
+- **Sandboxed by default** — capability-dropped container with seccomp hardening;
   the agent only sees the directory you mount.
 - **Three agents, one CLI** — switch between `pi`, `opencode`, and `hermes` with
   `-a`. Same flags, same flow.

--- a/docs/security.md
+++ b/docs/security.md
@@ -11,7 +11,6 @@ Harness layers protections at runtime, image, and dependency level.
 Each run starts the container with:
 
 - `--cap-drop=ALL --cap-add=NET_RAW` — minimal capability set
-- `--security-opt no-new-privileges:true` — block privilege escalation
 - `--security-opt seccomp=...` — inline seccomp profile blocks `socket(AF_ALG)`
   to prevent kernel crypto API access (a known container escape vector)
 - Only your mounted directory (or single file with `-f`) is visible to the agent

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -627,8 +627,6 @@ async function run(prompt: string | null): Promise<void> {
     "--cap-drop=ALL",
     "--cap-add=NET_RAW",
     "--security-opt",
-    "no-new-privileges:true",
-    "--security-opt",
     `seccomp=${SECCOMP_PROFILE}`,
     ...envFileArgs,
     ...cloudModeEnv,

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -550,13 +550,10 @@ test("docker invocation always includes hardening flags", () => {
   assert.ok(a.includes("--rm"));
   assert.ok(a.includes("--cap-drop=ALL"));
   assert.ok(a.includes("--cap-add=NET_RAW"));
+  // seccomp profile blocks AF_ALG socket creation
   const sIdx = a.indexOf("--security-opt");
   assert.notEqual(sIdx, -1);
-  assert.equal(a[sIdx + 1], "no-new-privileges:true");
-  // seccomp profile blocks AF_ALG socket creation
-  const sIdx2 = a.indexOf("--security-opt", sIdx + 1);
-  assert.notEqual(sIdx2, -1);
-  assert.match(a[sIdx2 + 1], /^seccomp=.*block-af-alg\.json$/);
+  assert.match(a[sIdx + 1], /^seccomp=.*block-af-alg\.json$/);
   // -w /workspace is set
   const wIdx = a.indexOf("-w");
   assert.notEqual(wIdx, -1);


### PR DESCRIPTION
## Summary

- Remove `--security-opt no-new-privileges:true` from the docker run invocation in `src/harness.ts`
- Update tests, README, and docs to reflect the change

## Problem

The `no-new-privileges` flag prevents `sudo` from gaining elevated capabilities, even for commands listed in `/etc/sudoers.d/harness` (`apt-get`, `apt`, `dpkg`). This makes the sudoers configuration useless — agents can't install packages inside the container.

## Root Cause

`no-new-privileges:true` is a Linux kernel feature that sets the `PR_SET_NO_NEW_PRIVS` bit, which prevents `execve()` from granting new privileges (including those from `setuid` binaries like `sudo`). This is incompatible with the sudoers-based package installation pattern.

## Fix

Remove the `no-new-privileges:true` security-opt. The remaining sandboxing is still strong:

- **`--cap-drop=ALL --cap-add=NET_RAW`** — minimal capability set, drops all Linux capabilities except raw socket
- **Seccomp profile** — blocks `socket(AF_ALG)` to prevent kernel crypto API access (known container escape vector)
- **User isolation** — container runs as unprivileged `harness` user, only sees the mounted workspace

## Test Plan

- [x] All 94 e2e tests pass
- [x] Build succeeds
- [x] Biome lint passes on changed files

Closes #89
