### PR TITLE
chore: bump gh 2.92.0 -> 2.93.0 and hermes-agent v2026.5.16 -> v2026.5.29.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable-slim@sha256:5012d0517aa0075a7150a45aae67586641e898913b7af3b08
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG GH_VERSION="2.92.0"
+ARG GH_VERSION="2.93.0"
 ARG MISE_VERSION="2026.4.23"
 ARG TARGETARCH
 

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -85,7 +85,7 @@ RUN set -eux && \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         python3 python3-dev python3-venv build-essential git libffi-dev libolm-dev \
-    && git clone --depth 1 --branch v2026.5.16 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
+    && git clone --depth 1 --branch v2026.5.29.2 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
     && uv venv /opt/hermes-agent/venv --python python3 \
     && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp,web,pty,matrix] "python-telegram-bot==22.6" "faster-whisper==1.2.1" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \


### PR DESCRIPTION
## Summary

Bump two dependencies that have passed the 7-day cooldown window:

- **gh** `2.92.0` → `2.93.0` (released 2026-05-27, 9 days old)
- **hermes-agent** `v2026.5.16` → `v2026.5.29.2` (released 2026-05-29, 7 days old)

Checked via the `check-deps` skill — all other deps are either up to date or still on cooldown.

## Files changed

- `Dockerfile` — `ARG GH_VERSION="2.93.0"`
- `Dockerfile.hermes` — `--branch v2026.5.29.2`
