### PR TITLE
feat: persist container ~/.config at the project level (#92)

### DIFF
--- a/src/harness.ts
+++ b/src/harness.ts
@@ -559,6 +559,15 @@ async function run(prompt: string | null): Promise<void> {
         fs.mkdirSync(hostFullPath, { recursive: true });
         volumeArgs.push("-v", `${hostFullPath}:${mount.containerPath}`);
       }
+      // Project-level (agent-independent) XDG config persistence. Tools like
+      // jj write to ~/.config; persisting it one level above the per-agent
+      // persistRoot lets that config survive across runs and be shared by every
+      // agent working in this project. For opencode the more-specific
+      // .config/opencode mount above nests inside this one (Docker mounts
+      // parents before children), so opencode keeps its own per-agent bucket.
+      const xdgConfigPath = path.join(path.dirname(persistRoot), "xdg_config");
+      fs.mkdirSync(xdgConfigPath, { recursive: true });
+      volumeArgs.push("-v", `${xdgConfigPath}:/home/harness/.config`);
       // Per-agent mise persistence (data: tools/plugins, state: trust settings)
       const miseDataPath = path.join(persistRoot, "mise");
       fs.mkdirSync(miseDataPath, { recursive: true });

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -2572,3 +2572,112 @@ test("--help documents --no-context-files and -nc", () => {
   assert.match(r.stdout, /--no-context-files/);
   assert.match(r.stdout, /-nc/);
 });
+
+// ---- project-level XDG config persistence (issue #92) ----------------------
+//
+// The container's ~/.config (/home/harness/.config) is persisted at the
+// project (cwd) level — `$XDG_DATA_HOME/harness/<normalized-cwd>/xdg_config` —
+// one level above the per-agent persist root, so config written by tools like
+// jj survives across runs and is shared across agents. Like the other persist
+// mounts, this only happens for interactive (non-ephemeral) sessions.
+
+function hasScript() {
+  return (
+    spawnSync("sh", ["-c", "command -v script"], { encoding: "utf8" })
+      .status === 0
+  );
+}
+
+test("interactive (PTY) persists ~/.config at XDG_DATA_HOME/harness/<cwd>/xdg_config", () => {
+  if (!hasScript()) return; // needs a PTY; ubuntu-latest has util-linux script
+  const localWork = fs.mkdtempSync(path.join(os.tmpdir(), "harness-e2e-cwd-"));
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "harness-e2e-home-"));
+  const xdgData = path.join(homeDir, ".local", "share");
+  fs.mkdirSync(xdgData, { recursive: true });
+  const r = spawnSync("script", ["-qfec", `node ${CLI}`, "/dev/null"], {
+    cwd: localWork,
+    env: {
+      ...process.env,
+      PATH: `${SHIM_DIR}:${process.env.PATH}`,
+      HARNESS_IMAGE_TAG: "test-tag",
+      HOME: homeDir,
+      XDG_DATA_HOME: xdgData,
+    },
+    encoding: "utf8",
+  });
+  assert.equal(r.status, 0, r.stderr);
+  const nCwd = normalizeCwd(localWork, homeDir);
+  // Host dir is created one level above the per-agent (pi) root.
+  assert.equal(
+    fs.existsSync(path.join(xdgData, "harness", nCwd, "xdg_config")),
+    true,
+    `XDG_DATA_HOME/harness/${nCwd}/xdg_config should be created interactively`,
+  );
+  // And the docker args mount it to the container's XDG config home.
+  const a = dockerArgs(r.stdout.replace(/\r/g, ""));
+  assert.ok(a, "expected DOCKER_INVOKED line");
+  assert.ok(
+    a.some((arg) => arg.endsWith(":/home/harness/.config")),
+    `expected -v mount ending in :/home/harness/.config in: ${a.join(" ")}`,
+  );
+});
+
+test("one-shot (-p) is ephemeral: no xdg_config dir, no ~/.config mount", () => {
+  const localWork = fs.mkdtempSync(path.join(os.tmpdir(), "harness-e2e-cwd-"));
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "harness-e2e-home-"));
+  const xdgData = path.join(homeDir, ".local", "share");
+  fs.mkdirSync(xdgData, { recursive: true });
+  const r = runCli(["-p", "noop"], {
+    extraEnv: { HOME: homeDir, XDG_DATA_HOME: xdgData },
+  });
+  assert.equal(r.status, 0, r.stderr);
+  const nCwd = normalizeCwd(WORK_DIR, homeDir);
+  assert.equal(
+    fs.existsSync(path.join(xdgData, "harness", nCwd, "xdg_config")),
+    false,
+    "xdg_config must NOT be created for one-shot (ephemeral) runs",
+  );
+  const a = dockerArgs(r.stdout);
+  assert.ok(a, "expected DOCKER_INVOKED line");
+  assert.equal(
+    a.some((arg) => arg.endsWith(":/home/harness/.config")),
+    false,
+    `ephemeral run must NOT mount /home/harness/.config: ${a.join(" ")}`,
+  );
+});
+
+test("opencode interactive keeps both the cwd-level .config and per-agent .config/opencode mounts", () => {
+  if (!hasScript()) return;
+  const localWork = fs.mkdtempSync(path.join(os.tmpdir(), "harness-e2e-cwd-"));
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "harness-e2e-home-"));
+  const xdgData = path.join(homeDir, ".local", "share");
+  fs.mkdirSync(xdgData, { recursive: true });
+  const r = spawnSync(
+    "script",
+    ["-qfec", `node ${CLI} -a opencode`, "/dev/null"],
+    {
+      cwd: localWork,
+      env: {
+        ...process.env,
+        PATH: `${SHIM_DIR}:${process.env.PATH}`,
+        HARNESS_IMAGE_TAG: "test-tag",
+        HOME: homeDir,
+        XDG_DATA_HOME: xdgData,
+      },
+      encoding: "utf8",
+    },
+  );
+  assert.equal(r.status, 0, r.stderr);
+  const a = dockerArgs(r.stdout.replace(/\r/g, ""));
+  assert.ok(a, "expected DOCKER_INVOKED line");
+  // Cwd-level whole-.config mount (issue #92) ...
+  assert.ok(
+    a.some((arg) => arg.endsWith(":/home/harness/.config")),
+    `expected cwd-level .config mount in: ${a.join(" ")}`,
+  );
+  // ... coexists with opencode's per-agent .config/opencode bucket.
+  assert.ok(
+    a.some((arg) => arg.endsWith(":/home/harness/.config/opencode")),
+    `expected per-agent .config/opencode mount in: ${a.join(" ")}`,
+  );
+});


### PR DESCRIPTION
## Summary

Closes #92.

Tools like **jj** write their config under `~/.config` inside the container, but that directory wasn't persisted — so the config was lost between runs. This persists the container's `/home/harness/.config` to the host.

## Where it persists

`$XDG_DATA_HOME/harness/<normalized-cwd>/xdg_config` → container `/home/harness/.config`

I put it at the **project (cwd) level — one level above the per-agent persist root** — matching the `normalized-cwd/xdg_config` path from the issue. That means the config is shared across every agent working in the same project (pi / opencode / hermes), which seems right for tool config like jj's. Only applies to interactive (non-ephemeral) sessions, like the other persist mounts.

## opencode nesting

opencode already persists `/home/harness/.config/opencode` per-agent. That mount **nests inside** the new cwd-level `.config` mount — Docker mounts parents before children, so opencode keeps its own per-agent bucket while the rest of `~/.config` persists at the cwd level. There's an e2e test locking that both mounts coexist.

## Design note / open question

One thing worth a sanity check: bind-mounting the whole `/home/harness/.config` shadows whatever the image ships there on first run (the host dir starts empty). The existing opencode `.config/opencode` mount already does this for its subpath, so the pattern is established — but if you'd rather scope this to specific subdirs (e.g. only `.config/jj`) instead of the whole XDG config home, easy to change. Went with the literal "mount ~/.config" reading from the issue.

## Tests

3 new e2e tests:
- interactive PTY creates `<cwd>/xdg_config` and mounts `/home/harness/.config`
- one-shot (`-p`) stays ephemeral — no dir, no mount
- opencode keeps **both** the cwd-level `.config` and per-agent `.config/opencode` mounts

Full suite **97 passing / 0 failing** locally (`pnpm test:e2e`); biome + build clean.

cc @capotej
