### PR TITLE
chore: bump gh, cosign, uv, hermes-agent

### DIFF
--- a/.agents/skills/check-deps/SKILL.md
+++ b/.agents/skills/check-deps/SKILL.md
@@ -17,7 +17,7 @@ This project pins eight external dependencies across its Dockerfiles. Check each
 
 | Dep | File | What's pinned | How to find latest |
 |-----|------|--------------|-------------------|
-| `@mariozechner/pi-coding-agent` | `Dockerfile` ~L52 | npm version in `pnpm install -g @mariozechner/pi-coding-agent@<VER>` | `npm show @mariozechner/pi-coding-agent version` |
+| `@earendil-works/pi-coding-agent` | `Dockerfile` ~L56 | npm version in `pnpm install -g @earendil-works/pi-coding-agent@<VER>` | `npm show @earendil-works/pi-coding-agent version` |
 | `opencode-ai` | `Dockerfile.opencode` ~L6 | npm version in `pnpm install -g opencode-ai@<VER>` | `npm show opencode-ai version` |
 | `hermes-agent` | `Dockerfile.hermes` ~L91 | git tag in `--branch <TAG>` | `gh release list --repo NousResearch/hermes-agent --limit 5` |
 | `gh` (GitHub CLI) | `Dockerfile` ~L5 | `ARG GH_VERSION=<VER>` | `gh release list --repo cli/cli --limit 5` |
@@ -37,7 +37,7 @@ This project pins eight external dependencies across its Dockerfiles. Check each
    - pnpm version (pattern: `corepack prepare pnpm@<VER>`)
 
 2. **Fetch latest versions in parallel** — run all version checks at the same time:
-   - npm packages: `npm show @mariozechner/pi-coding-agent version`, `npm show opencode-ai version`, `npm show pnpm version`
+   - npm packages: `npm show @earendil-works/pi-coding-agent version`, `npm show opencode-ai version`, `npm show pnpm version`
    - GitHub releases: `gh release list --repo <owner/repo> --limit 5` for hermes-agent, cli/cli, sigstore/cosign, astral-sh/uv
    - debian: `docker manifest inspect debian:stable-slim 2>/dev/null | python3 -c "import sys,json; m=json.load(sys.stdin); print(m.get('manifests',[{}])[0].get('digest','') if 'manifests' in m else m.get('config',{}).get('digest',''))"` — or simpler: `docker pull debian:stable-slim 2>&1 | grep -E 'Digest:|sha256:'`
 
@@ -45,7 +45,7 @@ This project pins eight external dependencies across its Dockerfiles. Check each
 
 4. **7-day cooldown check (all dependencies)** — Every dependency must be at least 7 days old before recommending an upgrade. Apply this to **all** dependencies, not just hermes-agent:
 
-   - **npm packages** (`@mariozechner/pi-coding-agent`, `opencode-ai`, `pnpm`): Get the publish date with `npm show <package> time` or `npm show <package> --json` and parse the `modified` / `created` field. Compute days since release.
+   - **npm packages** (`@earendil-works/pi-coding-agent`, `opencode-ai`, `pnpm`): Get the publish date with `npm show <package> time` or `npm show <package> --json` and parse the `modified` / `created` field. Compute days since release.
 
    - **GitHub releases** (`gh`, `cosign`, `uv`, `hermes-agent`): Use the publish date from the API response (`published_at` field when using `curl -s https://api.github.com/repos/<owner>/<repo>/releases?per_page=5` or column 4 from `gh release list`). Compute days since release.
 
@@ -72,7 +72,7 @@ This project pins eight external dependencies across its Dockerfiles. Check each
 ```text
 | Dependency                    | Pinned       | Latest       | Status          |
 |-------------------------------|--------------|--------------|-----------------|
-| @mariozechner/pi-coding-agent | 0.67.68      | 0.70.1       | outdated ⬆      |
+| @earendil-works/pi-coding-agent | 0.79.2       | 0.79.7       | up to date      |
 | opencode-ai                   | 1.14.18      | 1.14.18      | up to date      |
 | hermes-agent                  | v2026.4.16   | v2026.4.20   | on cooldown 🕐  |
 | gh                            | 2.91.0       | 2.91.0       | up to date      |

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ENV PNPM_MINIMUM_RELEASE_AGE=10080
 ENV PATH=$PNPM_HOME:$PATH
 
 RUN corepack enable && corepack prepare pnpm@10.33.2 --activate && \
-    pnpm install -g @mariozechner/pi-coding-agent@0.73.1 && \
+    pnpm install -g @earendil-works/pi-coding-agent@0.79.2 && \
     pnpm store prune && \
     rm -rf ~/.cache/pnpm ~/.npm && \
     mkdir -p /etc/harness/pi-defaults && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable-slim@sha256:5012d0517aa0075a7150a45aae67586641e898913b7af3b08
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG GH_VERSION="2.93.0"
+ARG GH_VERSION="2.94.0"
 ARG MISE_VERSION="2026.4.23"
 ARG TARGETARCH
 

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/capotej/harness:latest
-ARG UV_DIGEST=sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d
+ARG UV_DIGEST=sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6
 
 FROM ghcr.io/astral-sh/uv@${UV_DIGEST} AS uv-src
 
@@ -7,11 +7,11 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-ARG UV_VERSION=0.11.16
-ARG UV_DIGEST=sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d
-ARG COSIGN_VERSION=3.0.6
-ARG COSIGN_AMD64_SHA256=c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74
-ARG COSIGN_ARM64_SHA256=bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8
+ARG UV_VERSION=0.11.19
+ARG UV_DIGEST=sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6
+ARG COSIGN_VERSION=3.1.1
+ARG COSIGN_AMD64_SHA256=ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc
+ARG COSIGN_ARM64_SHA256=2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11
 ARG TARGETARCH
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -85,7 +85,7 @@ RUN set -eux && \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         python3 python3-dev python3-venv build-essential git libffi-dev libolm-dev \
-    && git clone --depth 1 --branch v2026.5.29.2 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
+    && git clone --depth 1 --branch v2026.6.5 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
     && uv venv /opt/hermes-agent/venv --python python3 \
     && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp,web,pty,matrix,bedrock] "python-telegram-bot==22.6" "faster-whisper==1.2.1" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \


### PR DESCRIPTION
## Dependency updates

| Dep | Pinned | Latest | Age |
|-----|--------|--------|-----|
| gh | 2.93.0 | **2.94.0** | 9d ✅ |
| cosign | 3.0.6 | **3.1.1** | 10d ✅ |
| uv | 0.11.16 | **0.11.19** | 15d ✅ |
| hermes-agent | v2026.5.29.2 | **v2026.6.5** | 12d ✅ |
| @earendil-works/pi-coding-agent | 0.73.1 → **0.79.2** | 0.79.7 | 7d ✅ |
| opencode-ai | 1.15.10 | 1.17.8 | 0d 🕐 |
| pnpm | 10.33.2 | 11.8.0 | 1d 🕐 |
| mise | 2026.4.23 | 2026.6.11 | 2d 🕐 |
| tirith | 0.2.12 | 0.3.2 | 2d 🕐 |

All updates respect the 7-day cooldown policy.

Run via the check-deps skill.