### PR TITLE
chore: rename capotej → boldblackai across repo

### DIFF
--- a/.agents/skills/analyze-image/SKILL.md
+++ b/.agents/skills/analyze-image/SKILL.md
@@ -13,12 +13,12 @@ Produces a three-part breakdown of the harness Docker image:
 
 ## Step 1: Determine target image
 
-Default to `ghcr.io/capotej/harness:latest` unless the user specifies a different tag.
+Default to `ghcr.io/boldblackai/harness:latest` unless the user specifies a different tag.
 
 ## Step 2: List all harness image tags
 
 ```bash
-docker images ghcr.io/capotej/harness --format "table {{.Tag}}\t{{.Size}}\t{{.CreatedAt}}"
+docker images ghcr.io/boldblackai/harness --format "table {{.Tag}}\t{{.Size}}\t{{.CreatedAt}}"
 ```
 
 ## Step 3: Per-layer breakdown

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -61,11 +61,11 @@ date +%Y-%m-%d
 
 Based on the commits collected, write a 1–3 sentence prose summary of what changed (new features, fixes, notable improvements). For any new user-visible features — especially new CLI flags, options, or agents — include a concrete inline example showing how to use them (e.g. `harness --flag value`). Then include the raw commit list beneath it.
 
-**Dockerfile dependency changes** — Diff `Dockerfile`, `Dockerfile.opencode`, and `Dockerfile.hermes` against the last tag to find any version bumps to installed tools (e.g. `@mariozechner/pi-coding-agent`, `opencode-ai`, `hermes-agent`, `uv`, `pnpm`, `debian`, etc.). If any are found, include a `### Dependency Updates` section listing each change as `- updated <package> from <old> to <new>`.
+**Dockerfile dependency changes** — Diff `Dockerfile`, `Dockerfile.opencode`, and `Dockerfile.hermes` against the last tag to find any version bumps to installed tools (e.g. `@earendil-works/pi-coding-agent`, `opencode-ai`, `hermes-agent`, `uv`, `pnpm`, `debian`, etc.). If any are found, include a `### Dependency Updates` section listing each change as `- updated <package> from <old> to <new>`.
 
 **Upstream release notes for pi, opencode, and hermes-agent** — If any of these three were bumped, fetch the release notes for every version between the old pin (exclusive) and the new pin (inclusive) and include them in a `### Upstream Release Notes` section. Run the fetches in parallel:
 
-- `@mariozechner/pi-coding-agent`: use `npm show @mariozechner/pi-coding-agent versions --json` to enumerate intermediate versions, then `gh release view <tag> --repo badlogic/pi-mono --json tagName,body` for each (tags match npm versions with a `v` prefix, e.g. `v0.70.2`)
+- `@earendil-works/pi-coding-agent`: use `npm show @earendil-works/pi-coding-agent versions --json` to enumerate intermediate versions, then `gh release view <tag> --repo badlogic/pi-mono --json tagName,body` for each (tags match npm versions with a `v` prefix, e.g. `v0.70.2`)
 - `opencode-ai`: `gh release view <tag> --repo sst/opencode --json tagName,body` for each version between old and new (tags are prefixed with `v`)
 - `hermes-agent`: `gh release view <tag> --repo NousResearch/hermes-agent --json tagName,body` for each tag between old and new
 
@@ -74,7 +74,7 @@ Summarize each release in 2–4 bullet points (new features, breaking changes, n
 ```markdown
 ### Upstream Release Notes
 
-#### @mariozechner/pi-coding-agent 0.67.68 → 0.70.2
+#### @earendil-works/pi-coding-agent 0.67.68 → 0.70.2
 
 **v0.68.0** — <2–4 bullet summary>
 **v0.68.1** — <2–4 bullet summary>
@@ -122,10 +122,10 @@ Edit the `version` field directly in `package.json`. Do not use `npm version` �
 
 ## Step 5b: Update hermes image tag in deploy guides
 
-The hermes claw deploy guides pin the upstream image tag (e.g. `ghcr.io/capotej/harness:hermes-1.8.1`). Update every occurrence to match the new `package.json` version. Each guide exists twice — the in-repo copy (`docs/deploying-to-*.md`, linked from README) and the docs-site copy (`docs/deploying/*.md`) — keep both in sync.
+The hermes claw deploy guides pin the upstream image tag (e.g. `ghcr.io/boldblackai/harness:hermes-1.8.1`). Update every occurrence to match the new `package.json` version. Each guide exists twice — the in-repo copy (`docs/deploying-to-*.md`, linked from README) and the docs-site copy (`docs/deploying/*.md`) — keep both in sync.
 
 ```toml
-image = "ghcr.io/capotej/harness:hermes-<new-version>"
+image = "ghcr.io/boldblackai/harness:hermes-<new-version>"
 ```
 
 Search for the pattern `hermes-[0-9]` in these files and replace all occurrences with the new version:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Skills mounting applies to all run modes (interactive, one-shot, `--file`). Non-
 
 Four GitHub Actions workflows (`.github/workflows/`):
 
-- **`docker.yml`** — Builds and pushes multi-arch (amd64 + arm64) images to `ghcr.io/capotej/harness` on push to `main` and on release tags. Signs images with cosign and attests SLSA provenance. Builds base first, then opencode and hermes variants in parallel using the base image digest.
+- **`docker.yml`** — Builds and pushes multi-arch (amd64 + arm64) images to `ghcr.io/boldblackai/harness` on push to `main` and on release tags. Signs images with cosign and attests SLSA provenance. Builds base first, then opencode and hermes variants in parallel using the base image digest.
 - **`lint.yml`** — Runs `pnpm lint` on push to `main` and on PRs.
 - **`e2e.yml`** — Runs `pnpm test:e2e` on all branches and PRs. Tests against Node 22 and 24.
 - **`pr-build.yml`** — Builds all three Docker images (base + variants) on PRs using a local registry to catch build failures before merge.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @capotej
+*       @boldblackai

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @capotej
+*       @boldblackai/maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @boldblackai
+*       @capotej

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/capotej/harness:latest
+ARG BASE_IMAGE=ghcr.io/boldblackai/harness:latest
 ARG UV_DIGEST=sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6
 
 FROM ghcr.io/astral-sh/uv@${UV_DIGEST} AS uv-src

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/capotej/harness:latest
+ARG BASE_IMAGE=ghcr.io/boldblackai/harness:latest
 FROM ${BASE_IMAGE}
 
 USER root

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REGISTRY := ghcr.io/capotej/harness
+REGISTRY := ghcr.io/boldblackai/harness
 ARCH ?= $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
 
 build:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and [`hermes`](https://github.com/NousResearch/hermes-agent) — so you can poin
 - **Stateful or one-shot** — interactive runs persist agent state under `$XDG_DATA_HOME/harness/<project>/<agent>/` (defaults to `~/.local/share/harness/`); one-shot prompts (`-p` or piped stdin) stay ephemeral.
 - **User skills** — automatically mounts `~/.agents/skills` and `~/.claude/skills` into the container so agents can discover and use custom skills. Disable with `--no-skills`.
 - **Context files** — automatically mounts `~/.agents/AGENTS.md` and `~/.claude/CLAUDE.md` into the agent's context directory so cross-agent rules apply inside the container. Disable with `--no-context-files` (`-nc`).
-- **Zero install** — `npx @capotej/harness` just works.
+- **Zero install** — `npx @boldblackai/harness` just works.
 
 ## Quickstart
 
@@ -37,7 +37,7 @@ The container is preconfigured to use `gemma-4-e4b` via LM Studio's local API.
 You can also specify a different local model with `-m`. HuggingFace-style names with slashes (e.g. `qwen/qwen3.5-9b`) work correctly in local mode:
 
 ```bash
-npx @capotej/harness -m "qwen/qwen3.5-9b" -p "write a fizzbuzz in Go"
+npx @boldblackai/harness -m "qwen/qwen3.5-9b" -p "write a fizzbuzz in Go"
 ```
 
 ### Using a cloud provider instead
@@ -66,7 +66,7 @@ See the [full list of supported providers](https://github.com/badlogic/pi-mono/b
 
 ```bash
 echo 'OPENROUTER_API_KEY=sk-...' > .env
-npx @capotej/harness -e .env -p "write me a fizzbuzz in Go"
+npx @boldblackai/harness -e .env -p "write me a fizzbuzz in Go"
 ```
 
 That's it. Your current directory is mounted at `/workspace` inside the container and the agent works against it.
@@ -94,36 +94,36 @@ That's it. Your current directory is mounted at `/workspace` inside the containe
 
 ```bash
 # One-shot prompt
-npx @capotej/harness -p "write me a fizzbuzz in Go"
+npx @boldblackai/harness -p "write me a fizzbuzz in Go"
 
 # Pipe via stdin
-echo "write me a fizzbuzz in Go" | npx @capotej/harness
+echo "write me a fizzbuzz in Go" | npx @boldblackai/harness
 
 # Interactive session (no -p, no piped stdin) — state persists under XDG data dir
-npx @capotej/harness
+npx @boldblackai/harness
 
 # Use a cloud provider via env file
-npx @capotej/harness -e .env -p "add a login endpoint"
+npx @boldblackai/harness -e .env -p "add a login endpoint"
 
 # Override the model
-npx @capotej/harness -m anthropic/claude-sonnet-4-5 -p "refactor the auth module"
+npx @boldblackai/harness -m anthropic/claude-sonnet-4-5 -p "refactor the auth module"
 
 # Mount a single file instead of the whole directory
-npx @capotej/harness -f ./script.py -p "add type hints"
+npx @boldblackai/harness -f ./script.py -p "add type hints"
 
 # Switch agents
-npx @capotej/harness -a opencode -p "write me a fizzbuzz in Go"
-npx @capotej/harness -a hermes -e .env -p "add tests"
+npx @boldblackai/harness -a opencode -p "write me a fizzbuzz in Go"
+npx @boldblackai/harness -a hermes -e .env -p "add tests"
 ```
 
 `npx`, `bunx`, and `pnpm dlx` are interchangeable. Or install globally:
 
 ```bash
-npm install -g @capotej/harness
+npm install -g @boldblackai/harness
 # or
-pnpm add -g @capotej/harness
+pnpm add -g @boldblackai/harness
 # or
-bun add -g @capotej/harness
+bun add -g @boldblackai/harness
 ```
 
 ## Agents
@@ -153,14 +153,14 @@ See the [full provider list](https://github.com/badlogic/pi-mono/blob/c779c14e91
 [`opencode`](https://opencode.ai) defaults to LM Studio in local mode. Pass `--env-file` to enter cloud mode — the agent auto-detects the provider from whichever API key is in the file (`ZAI_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, etc.). The `-m` flag takes a bare model name; the provider prefix is added for you.
 
 ```bash
-npx @capotej/harness -a opencode -e .env -p "refactor the auth module"
-npx @capotej/harness -a opencode -e .env -m anthropic/claude-sonnet-4-5 -p "add tests"
+npx @boldblackai/harness -a opencode -e .env -p "refactor the auth module"
+npx @boldblackai/harness -a opencode -e .env -m anthropic/claude-sonnet-4-5 -p "add tests"
 ```
 
 To pass env vars but stay in local mode, use `--local`:
 
 ```bash
-npx @capotej/harness -a opencode -e .env --local -p "refactor the auth module"
+npx @boldblackai/harness -a opencode -e .env --local -p "refactor the auth module"
 ```
 
 When using LM Studio locally, set the model's context length to at least 32k tokens.
@@ -170,8 +170,8 @@ When using LM Studio locally, set the model's context length to at least 32k tok
 [`hermes`](https://github.com/NousResearch/hermes-agent) by NousResearch supports many providers. Pass `--env-file` to enter cloud mode — the agent auto-detects the provider from whichever API key is in the file. Use a `provider/model` for `-m`:
 
 ```bash
-npx @capotej/harness -a hermes -e .env -m anthropic/claude-sonnet-4-5 -p "add tests"
-npx @capotej/harness -a hermes -e .env -m openrouter/auto -p "add tests"
+npx @boldblackai/harness -a hermes -e .env -m anthropic/claude-sonnet-4-5 -p "add tests"
+npx @boldblackai/harness -a hermes -e .env -m openrouter/auto -p "add tests"
 ```
 
 Common keys: `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, [and others](https://github.com/NousResearch/hermes-agent/blob/main/.env.example). LM Studio context length should be at least 64k tokens.
@@ -200,7 +200,7 @@ brew install cosign
 Verified digests are cached at `~/.cache/harness/cosign-verified.json` so verification only runs once per image. Skip with `--no-verify` (or by setting `HARNESS_IMAGE_TAG`, which implies skip):
 
 ```bash
-npx @capotej/harness --no-verify -p "write me a fizzbuzz in Go"
+npx @boldblackai/harness --no-verify -p "write me a fizzbuzz in Go"
 ```
 
 ### Dependency cooldown
@@ -266,7 +266,7 @@ Link your local checkout globally:
 ```bash
 pnpm link --global
 # unlink with:
-pnpm unlink --global @capotej/harness
+pnpm unlink --global @boldblackai/harness
 ```
 
 ### Building the image
@@ -275,7 +275,7 @@ pnpm unlink --global @capotej/harness
 make image
 ```
 
-Builds `ghcr.io/capotej/harness` with Debian stable-slim, Node.js v24, `git`, [`@mariozechner/pi-coding-agent`](https://pi.dev/), [`opencode-ai`](https://opencode.ai), [`hermes-agent`](https://github.com/NousResearch/hermes-agent), `fd`, `ripgrep`, `jq`, and `curl`. The hermes variant also includes the [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) for connecting to MCP servers, and [`faster-whisper`](https://github.com/SYSTRAN/faster-whisper) for local speech-to-text.
+Builds `ghcr.io/boldblackai/harness` with Debian stable-slim, Node.js v24, `git`, [`@earendil-works/pi-coding-agent`](https://pi.dev/), [`opencode-ai`](https://opencode.ai), [`hermes-agent`](https://github.com/NousResearch/hermes-agent), `fd`, `ripgrep`, `jq`, and `curl`. The hermes variant also includes the [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) for connecting to MCP servers, and [`faster-whisper`](https://github.com/SYSTRAN/faster-whisper) for local speech-to-text.
 
 The base image is pinned by manifest-list digest (the OCI image index, not a per-platform manifest) for reproducible multi-arch builds. To bump it:
 

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -9,7 +9,7 @@ icon: lucide/bot
 ## Local mode
 
 ```bash
-npx @capotej/harness -a hermes -p "add tests"
+npx @boldblackai/harness -a hermes -p "add tests"
 ```
 
 LM Studio context length should be at least 64k tokens.
@@ -20,8 +20,8 @@ Pass `--env-file` to enter cloud mode — the agent auto-detects the provider fr
 
 ```bash
 echo "ANTHROPIC_API_KEY=sk-ant-***" > .env
-npx @capotej/harness -a hermes -e .env -p "add tests"
-npx @capotej/harness -a hermes -e .env -m openrouter/auto -p "add tests"
+npx @boldblackai/harness -a hermes -e .env -p "add tests"
+npx @boldblackai/harness -a hermes -e .env -m openrouter/auto -p "add tests"
 ```
 
 Common keys: `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`. [See full list](https://github.com/NousResearch/hermes-agent/blob/main/.env.example).

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -9,7 +9,7 @@ icon: lucide/terminal
 ## Local mode
 
 ```bash
-npx @capotej/harness -a opencode -p "write a fizzbuzz in Go"
+npx @boldblackai/harness -a opencode -p "write a fizzbuzz in Go"
 ```
 
 When using LM Studio locally, set the model's context length to at least 32k tokens.
@@ -20,8 +20,8 @@ The entrypoint detects the provider from your env file. Priority order: Anthropi
 
 ```bash
 echo "OPENROUTER_API_KEY=sk-or-***" > .env
-npx @capotej/harness -a opencode -e .env -p "refactor the auth module"
-npx @capotej/harness -a opencode -e .env -m anthropic/claude-sonnet-4-5 -p "add tests"
+npx @boldblackai/harness -a opencode -e .env -p "refactor the auth module"
+npx @boldblackai/harness -a opencode -e .env -m anthropic/claude-sonnet-4-5 -p "add tests"
 ```
 
 Supported keys:
@@ -39,5 +39,5 @@ The `-m` flag takes a bare model name; the provider prefix is added automaticall
 To pass env vars but stay in local mode:
 
 ```bash
-npx @capotej/harness -a opencode -e .env --local -p "refactor the auth module"
+npx @boldblackai/harness -a opencode -e .env --local -p "refactor the auth module"
 ```

--- a/docs/agents/pi.md
+++ b/docs/agents/pi.md
@@ -11,13 +11,13 @@ icon: lucide/cpu
 Pi defaults to LM Studio with `google/gemma-4-e4b` (16k context is sufficient):
 
 ```bash
-npx @capotej/harness -p "write a fizzbuzz in Go"
+npx @boldblackai/harness -p "write a fizzbuzz in Go"
 ```
 
 You can specify a different local model with `-m`. HuggingFace-style names with slashes work correctly:
 
 ```bash
-npx @capotej/harness -m "qwen/qwen3.5-9b" -p "write a fizzbuzz in Go"
+npx @boldblackai/harness -m "qwen/qwen3.5-9b" -p "write a fizzbuzz in Go"
 ```
 
 ## Cloud mode
@@ -42,13 +42,13 @@ See the [full provider list](https://github.com/badlogic/pi-mono/blob/c779c14e91
 
 ```bash
 # One-shot prompt
-npx @capotej/harness -p "add a login endpoint"
+npx @boldblackai/harness -p "add a login endpoint"
 
 # With a specific model
-npx @capotej/harness -m anthropic/claude-sonnet-4-5 -p "refactor auth"
+npx @boldblackai/harness -m anthropic/claude-sonnet-4-5 -p "refactor auth"
 
 # Interactive session (no -p)
-npx @capotej/harness
+npx @boldblackai/harness
 ```
 
 The `-m` flag is passed directly to pi as `--model`.

--- a/docs/deploying-to-aws.md
+++ b/docs/deploying-to-aws.md
@@ -26,7 +26,7 @@ Set a couple of shell variables used throughout:
 ```bash
 export AWS_REGION=us-east-1
 export CLAW_NAME=hermes-claw
-export HARNESS_IMAGE=ghcr.io/capotej/harness:hermes-1.8.4
+export HARNESS_IMAGE=ghcr.io/boldblackai/harness:hermes-1.8.4
 ```
 
 ---
@@ -177,7 +177,7 @@ Save this as `taskdef.json` (substitute `<ACCOUNT_ID>`, `<AWS_REGION>`, `<EFS_ID
   "taskRoleArn": "arn:aws:iam::<ACCOUNT_ID>:role/hermes-claw-task",
   "containerDefinitions": [{
     "name": "hermes",
-    "image": "ghcr.io/capotej/harness:hermes-1.8.4",
+    "image": "ghcr.io/boldblackai/harness:hermes-1.8.4",
     "essential": true,
     "command": ["hermes", "gateway"],
     "user": "1000:1000",
@@ -270,7 +270,7 @@ aws ecs execute-command --region "$AWS_REGION" \
 The fly.io guide's [`[[files]]` injection pattern](deploying-to-fly.md#customizing-the-claw--dont-extend-the-image) translates to two AWS techniques:
 
 - **Runtime-mutable files (config, persona, persistent skills)** — seed them once on the EFS volume, then let hermes own them. Either `aws ecs execute-command` into a running task and `cp` them into place, or run a one-off Fargate task with the same EFS mount that drops files into `/etc/harness/hermes-defaults/openrouter/` before the gateway starts. The base image's `entrypoint-hermes.sh` does `cp -rn` from `/etc/harness/hermes-defaults/openrouter/` into the volume on first boot only — same first-boot-only semantics as fly.
-- **Tool wrappers / scripts (refreshed every deploy)** — bake them into a tiny sidecar layer published to ECR `FROM scratch`, mount it via a shared `bind` volume between an `initContainer`-style sidecar (using `dependsOn: { condition: COMPLETE }`) and the hermes container. Or: store them in S3 and `aws s3 sync` them in via a startup hook. Avoid `FROM ghcr.io/capotej/harness` — see the fly doc for why.
+- **Tool wrappers / scripts (refreshed every deploy)** — bake them into a tiny sidecar layer published to ECR `FROM scratch`, mount it via a shared `bind` volume between an `initContainer`-style sidecar (using `dependsOn: { condition: COMPLETE }`) and the hermes container. Or: store them in S3 and `aws s3 sync` them in via a startup hook. Avoid `FROM ghcr.io/boldblackai/harness` — see the fly doc for why.
 
 ### Fargate teardown
 
@@ -386,7 +386,7 @@ ExecStart=/usr/bin/docker run --rm --name hermes-claw \
   -e HERMES_HOME=/home/harness/.hermes-openrouter \
   -e HF_HOME=/home/harness/.hermes-openrouter/.cache/huggingface \
   -v /var/lib/hermes-claw:/home/harness/.hermes-openrouter \
-  ghcr.io/capotej/harness:hermes-1.8.4 \
+  ghcr.io/boldblackai/harness:hermes-1.8.4 \
   hermes gateway
 ExecStop=/usr/bin/docker stop hermes-claw
 

--- a/docs/deploying-to-fly.md
+++ b/docs/deploying-to-fly.md
@@ -22,7 +22,7 @@ primary_region = "iad"
   HF_HOME = "/home/harness/.hermes-openrouter/.cache/huggingface"
 
 [build]
-  image = "ghcr.io/capotej/harness:hermes-1.8.4"
+  image = "ghcr.io/boldblackai/harness:hermes-1.8.4"
 
 [processes]
   app = "hermes gateway"
@@ -60,7 +60,7 @@ Message the bot via Telegram, or wire it up to a scheduled workflow — see the 
 
 ## Customizing the claw — *don't* extend the image
 
-When you want to give the claw extra capabilities (tool wrappers around your APIs, an opinionated initial system prompt, custom `gh`-style scripts), the temptation is to write a `Dockerfile` that does `FROM ghcr.io/capotej/harness:hermes-1.8.4` and bakes everything in. **Don't.** Two problems:
+When you want to give the claw extra capabilities (tool wrappers around your APIs, an opinionated initial system prompt, custom `gh`-style scripts), the temptation is to write a `Dockerfile` that does `FROM ghcr.io/boldblackai/harness:hermes-1.8.4` and bakes everything in. **Don't.** Two problems:
 
 1. The fly volume mounts on top of `/home/harness/.hermes-openrouter`, which silently hides anything you `COPY` into that path on first boot.
 2. Hermes treats `config.yaml` as mutable state — TUI tweaks, model switches, and persona toggles are persisted via `save_config()`. A derived image fights that ownership.

--- a/docs/deploying-to-k8s.md
+++ b/docs/deploying-to-k8s.md
@@ -9,7 +9,7 @@ long-running "claw" (a persistent agent process) to a K8s cluster using the harn
 
 | Component | Description |
 |---|---|
-| **Deployment** | Single-replica pod running `ghcr.io/capotej/harness:hermes-1.8.4` |
+| **Deployment** | Single-replica pod running `ghcr.io/boldblackai/harness:hermes-1.8.4` |
 | **PVC** | 100Gi persistent volume for agent data (`/home/harness/.hermes-openrouter`) |
 | **PDB** | PodDisruptionBudget ensuring at least 1 pod is available |
 | **Secrets** | API keys sourced from a K8s Secret (`k8sclaw-secrets`) |
@@ -18,7 +18,7 @@ long-running "claw" (a persistent agent process) to a K8s cluster using the harn
 
 - A Kubernetes cluster ≥ 1.21 (k3s or any compatible runtime)
 - `kubectl` installed and configured with cluster access
-- Container image access to `ghcr.io/capotej/harness:hermes-1.8.4`
+- Container image access to `ghcr.io/boldblackai/harness:hermes-1.8.4`
 - A default StorageClass provisioned (or specify one in `k8sclaw.yaml`)
 
 ## Deploy
@@ -98,7 +98,7 @@ spec:
         runAsGroup: 1000
       containers:
         - name: k8sclaw
-          image: ghcr.io/capotej/harness:hermes-1.8.4
+          image: ghcr.io/boldblackai/harness:hermes-1.8.4
           imagePullPolicy: Always
           command: ["/tini", "--", "hermes", "gateway"]
           lifecycle:

--- a/docs/deploying/aws.md
+++ b/docs/deploying/aws.md
@@ -26,7 +26,7 @@ Set a couple of shell variables used throughout:
 ```bash
 export AWS_REGION=us-east-1
 export CLAW_NAME=hermes-claw
-export HARNESS_IMAGE=ghcr.io/capotej/harness:hermes-1.8.4
+export HARNESS_IMAGE=ghcr.io/boldblackai/harness:hermes-1.8.4
 ```
 
 ---
@@ -177,7 +177,7 @@ Save this as `taskdef.json` (substitute `<ACCOUNT_ID>`, `<AWS_REGION>`, `<EFS_ID
   "taskRoleArn": "arn:aws:iam::<ACCOUNT_ID>:role/hermes-claw-task",
   "containerDefinitions": [{
     "name": "hermes",
-    "image": "ghcr.io/capotej/harness:hermes-1.8.4",
+    "image": "ghcr.io/boldblackai/harness:hermes-1.8.4",
     "essential": true,
     "command": ["hermes", "gateway"],
     "user": "1000:1000",
@@ -270,7 +270,7 @@ aws ecs execute-command --region "$AWS_REGION" \
 The fly.io guide's [`[[files]]` injection pattern](fly.md#customizing-the-claw--dont-extend-the-image) translates to two AWS techniques:
 
 - **Runtime-mutable files (config, persona, persistent skills)** — seed them once on the EFS volume, then let hermes own them. Either `aws ecs execute-command` into a running task and `cp` them into place, or run a one-off Fargate task with the same EFS mount that drops files into `/etc/harness/hermes-defaults/openrouter/` before the gateway starts. The base image's `entrypoint-hermes.sh` does `cp -rn` from `/etc/harness/hermes-defaults/openrouter/` into the volume on first boot only — same first-boot-only semantics as fly.
-- **Tool wrappers / scripts (refreshed every deploy)** — bake them into a tiny sidecar layer published to ECR `FROM scratch`, mount it via a shared `bind` volume between an `initContainer`-style sidecar (using `dependsOn: { condition: COMPLETE }`) and the hermes container. Or: store them in S3 and `aws s3 sync` them in via a startup hook. Avoid `FROM ghcr.io/capotej/harness` — see the fly doc for why.
+- **Tool wrappers / scripts (refreshed every deploy)** — bake them into a tiny sidecar layer published to ECR `FROM scratch`, mount it via a shared `bind` volume between an `initContainer`-style sidecar (using `dependsOn: { condition: COMPLETE }`) and the hermes container. Or: store them in S3 and `aws s3 sync` them in via a startup hook. Avoid `FROM ghcr.io/boldblackai/harness` — see the fly doc for why.
 
 ### Fargate teardown
 
@@ -386,7 +386,7 @@ ExecStart=/usr/bin/docker run --rm --name hermes-claw \
   -e HERMES_HOME=/home/harness/.hermes-openrouter \
   -e HF_HOME=/home/harness/.hermes-openrouter/.cache/huggingface \
   -v /var/lib/hermes-claw:/home/harness/.hermes-openrouter \
-  ghcr.io/capotej/harness:hermes-1.8.4 \
+  ghcr.io/boldblackai/harness:hermes-1.8.4 \
   hermes gateway
 ExecStop=/usr/bin/docker stop hermes-claw
 

--- a/docs/deploying/fly.md
+++ b/docs/deploying/fly.md
@@ -22,7 +22,7 @@ primary_region = "iad"
   HF_HOME = "/home/harness/.hermes-openrouter/.cache/huggingface"
 
 [build]
-  image = "ghcr.io/capotej/harness:hermes-1.8.4"
+  image = "ghcr.io/boldblackai/harness:hermes-1.8.4"
 
 [processes]
   app = "hermes gateway"
@@ -60,7 +60,7 @@ Message the bot via Telegram, or wire it up to a scheduled workflow — see the 
 
 ## Customizing the claw — *don't* extend the image
 
-When you want to give the claw extra capabilities (tool wrappers around your APIs, an opinionated initial system prompt, custom `gh`-style scripts), the temptation is to write a `Dockerfile` that does `FROM ghcr.io/capotej/harness:hermes-1.8.4` and bakes everything in. **Don't.** Two problems:
+When you want to give the claw extra capabilities (tool wrappers around your APIs, an opinionated initial system prompt, custom `gh`-style scripts), the temptation is to write a `Dockerfile` that does `FROM ghcr.io/boldblackai/harness:hermes-1.8.4` and bakes everything in. **Don't.** Two problems:
 
 1. The fly volume mounts on top of `/home/harness/.hermes-openrouter`, which silently hides anything you `COPY` into that path on first boot.
 2. Hermes treats `config.yaml` as mutable state — TUI tweaks, model switches, and persona toggles are persisted via `save_config()`. A derived image fights that ownership.

--- a/docs/deploying/k8s.md
+++ b/docs/deploying/k8s.md
@@ -9,7 +9,7 @@ long-running "claw" (a persistent agent process) to a K8s cluster using the harn
 
 | Component | Description |
 |---|---|
-| **Deployment** | Single-replica pod running `ghcr.io/capotej/harness:hermes-1.8.4` |
+| **Deployment** | Single-replica pod running `ghcr.io/boldblackai/harness:hermes-1.8.4` |
 | **PVC** | 100Gi persistent volume for agent data (`/home/harness/.hermes-openrouter`) |
 | **PDB** | PodDisruptionBudget ensuring at least 1 pod is available |
 | **Secrets** | API keys sourced from a K8s Secret (`k8sclaw-secrets`) |
@@ -18,7 +18,7 @@ long-running "claw" (a persistent agent process) to a K8s cluster using the harn
 
 - A Kubernetes cluster ≥ 1.21 (k3s or any compatible runtime)
 - `kubectl` installed and configured with cluster access
-- Container image access to `ghcr.io/capotej/harness:hermes-1.8.4`
+- Container image access to `ghcr.io/boldblackai/harness:hermes-1.8.4`
 - A default StorageClass provisioned (or specify one in `k8sclaw.yaml`)
 
 ## Deploy
@@ -98,7 +98,7 @@ spec:
         runAsGroup: 1000
       containers:
         - name: k8sclaw
-          image: ghcr.io/capotej/harness:hermes-1.8.4
+          image: ghcr.io/boldblackai/harness:hermes-1.8.4
           imagePullPolicy: Always
           command: ["/tini", "--", "hermes", "gateway"]
           lifecycle:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,17 +14,17 @@ icon: lucide/rocket
 No installation required. Run directly with `npx`:
 
 ```bash
-npx @capotej/harness
+npx @boldblackai/harness
 ```
 
 Or install globally:
 
 ```bash
-npm install -g @capotej/harness
+npm install -g @boldblackai/harness
 # or
-pnpm add -g @capotej/harness
+pnpm add -g @boldblackai/harness
 # or
-bun add -g @capotej/harness
+bun add -g @boldblackai/harness
 ```
 
 ## Local mode (LM Studio)
@@ -39,7 +39,7 @@ lms get google/gemma-4-e4b
 Run harness:
 
 ```bash
-npx @capotej/harness -p "write a fizzbuzz in Go"
+npx @boldblackai/harness -p "write a fizzbuzz in Go"
 ```
 
 ### Interactive sessions
@@ -47,13 +47,13 @@ npx @capotej/harness -p "write a fizzbuzz in Go"
 Run without `-p` for an interactive session — agent state persists across runs:
 
 ```bash
-npx @capotej/harness
+npx @boldblackai/harness
 ```
 
 ### Pipe input
 
 ```bash
-echo "write me a fizzbuzz in Go" | npx @capotej/harness
+echo "write me a fizzbuzz in Go" | npx @boldblackai/harness
 ```
 
 ## Cloud mode
@@ -62,29 +62,29 @@ Pass an `--env-file` containing your API key to use a cloud provider:
 
 ```bash
 echo "ANTHROPIC_API_KEY=sk-ant-***" > .env
-npx @capotej/harness -e .env -p "add a login endpoint"
+npx @boldblackai/harness -e .env -p "add a login endpoint"
 ```
 
 To pass env vars but stay in local mode, use `--local`:
 
 ```bash
-npx @capotej/harness -e .env --local -p "refactor the auth module"
+npx @boldblackai/harness -e .env --local -p "refactor the auth module"
 ```
 
 ## Common flags
 
 ```bash
 # Choose an agent
-npx @capotej/harness -a opencode -p "write tests"
+npx @boldblackai/harness -a opencode -p "write tests"
 
 # Override the model
-npx @capotej/harness -m anthropic/claude-sonnet-4-5 -p "refactor auth"
+npx @boldblackai/harness -m anthropic/claude-sonnet-4-5 -p "refactor auth"
 
 # Mount a single file instead of the directory
-npx @capotej/harness -f ./script.py -p "add type hints"
+npx @boldblackai/harness -f ./script.py -p "add type hints"
 
 # Skip image verification
-npx @capotej/harness --no-verify -p "quick task"
+npx @boldblackai/harness --no-verify -p "quick task"
 ```
 
 See the full reference at [Configuration](configuration.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ one at a directory (or file) without giving it access to your entire machine.
   `--env-file` to use Anthropic, OpenRouter, OpenAI, Gemini, and others.
 - **Stateful or one-shot** — interactive runs persist agent state; one-shot
   prompts stay ephemeral.
-- **Zero install** — `npx @capotej/harness` just works.
+- **Zero install** — `npx @boldblackai/harness` just works.
 
 ## Quick start
 
@@ -37,7 +37,7 @@ lms get google/gemma-4-e4b
 Then run:
 
 ```bash
-npx @capotej/harness -p "write a fizzbuzz in Go"
+npx @boldblackai/harness -p "write a fizzbuzz in Go"
 ```
 
 See the [Getting Started](getting-started.md) guide for more details.

--- a/docs/security.md
+++ b/docs/security.md
@@ -31,7 +31,7 @@ verification only runs once per image. Skip with `--no-verify` (or by setting
 `HARNESS_IMAGE_TAG`, which implies skip):
 
 ```bash
-npx @capotej/harness --no-verify -p "write a fizzbuzz in Go"
+npx @boldblackai/harness --no-verify -p "write a fizzbuzz in Go"
 ```
 
 ## Dependency cooldown

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@capotej/harness",
+  "name": "@boldblackai/harness",
   "version": "1.8.4",
   "description": "Portable environment for running coding agents in a container",
   "bin": {
@@ -8,7 +8,7 @@
   "files": ["bin/"],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/capotej/harness.git"
+    "url": "git+https://github.com/boldblackai/harness.git"
   },
   "packageManager": "pnpm@10.33.2",
   "license": "MIT",

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -134,7 +134,7 @@ class HermesAdapter implements AgentAdapter {
 }
 
 const IDENTITY_REGEXP =
-  "https://github.com/capotej/harness/.github/workflows/docker.yml@refs/tags/";
+  "https://github.com/boldblackai/harness/.github/workflows/docker.yml@refs/tags/";
 const OIDC_ISSUER = "https://token.actions.githubusercontent.com";
 
 interface CosignError extends NodeJS.ErrnoException {
@@ -359,7 +359,7 @@ You can also pipe text to harness as an implied -p:
 `;
 
 const workspace = process.cwd();
-const REGISTRY = "ghcr.io/capotej/harness";
+const REGISTRY = "ghcr.io/boldblackai/harness";
 const VERSION: string = require("../package.json").version;
 const IMAGE_TAG = process.env.HARNESS_IMAGE_TAG ?? VERSION;
 

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -192,7 +192,7 @@ test("HARNESS_IMAGE_TAG short-circuits cosign verification", () => {
   assert.ok(args, "expected DOCKER_INVOKED line");
   // image is the last positional before container cmd; for pi it's REGISTRY:test-tag
   assert.ok(
-    args.some((a) => a === "ghcr.io/capotej/harness:test-tag"),
+    args.some((a) => a === "ghcr.io/boldblackai/harness:test-tag"),
     `expected pi image in args: ${args.join(" ")}`,
   );
 });
@@ -340,7 +340,7 @@ test("opencode: image tag is `opencode-<version>`", () => {
   assert.equal(r.status, 0, r.stderr);
   const a = dockerArgs(r.stdout);
   assert.ok(
-    a.some((s) => s === "ghcr.io/capotej/harness:opencode-test-tag"),
+    a.some((s) => s === "ghcr.io/boldblackai/harness:opencode-test-tag"),
     `expected opencode image: ${a.join(" ")}`,
   );
 });
@@ -384,7 +384,7 @@ test("opencode: --model is passed via OPENCODE_MODEL env, not CLI", () => {
   // container cmd is just `opencode run noop`
   const cmdIdx = a.indexOf(
     "opencode",
-    a.indexOf("ghcr.io/capotej/harness:opencode-test-tag"),
+    a.indexOf("ghcr.io/boldblackai/harness:opencode-test-tag"),
   );
   assert.deepEqual(a.slice(cmdIdx, cmdIdx + 3), ["opencode", "run", "noop"]);
 });
@@ -1745,9 +1745,9 @@ test("--volumes is forwarded alongside --file mode (both mounts present)", () =>
 
 test("image tag mapping: pi gets bare tag, opencode/hermes get adapter-prefixed tags", () => {
   // getImage() at src/harness.ts has an asymmetric rule:
-  //   pi       -> ghcr.io/capotej/harness:<TAG>
-  //   opencode -> ghcr.io/capotej/harness:opencode-<TAG>
-  //   hermes   -> ghcr.io/capotej/harness:hermes-<TAG>
+  //   pi       -> ghcr.io/boldblackai/harness:<TAG>
+  //   opencode -> ghcr.io/boldblackai/harness:opencode-<TAG>
+  //   hermes   -> ghcr.io/boldblackai/harness:hermes-<TAG>
   //
   // The existing test at line 309 (`opencode: image tag is "opencode-<version>"`)
   // only covers the opencode prefix path. Lock the **full mapping** here so
@@ -1767,14 +1767,14 @@ test("image tag mapping: pi gets bare tag, opencode/hermes get adapter-prefixed 
     assert.equal(r.status, 0, r.stderr);
     const a = dockerArgs(r.stdout);
     assert.ok(a, `expected DOCKER_INVOKED line for ${agent}`);
-    const expectedImage = `ghcr.io/capotej/harness:${expectedTag}`;
+    const expectedImage = `ghcr.io/boldblackai/harness:${expectedTag}`;
     assert.ok(
       a.includes(expectedImage),
       `expected image '${expectedImage}' for agent '${agent}' in: ${a.join(" ")}`,
     );
     // Negative: the pi-prefixed form must NEVER appear.
     assert.equal(
-      a.some((arg) => arg.startsWith("ghcr.io/capotej/harness:pi-")),
+      a.some((arg) => arg.startsWith("ghcr.io/boldblackai/harness:pi-")),
       false,
       `pi must never get a 'pi-' prefix; got: ${a.join(" ")}`,
     );
@@ -1796,7 +1796,7 @@ test("default agent (no -a/--agent) is pi and image tag has no adapter prefix", 
   const a = dockerArgs(r.stdout);
   assert.ok(a, "expected DOCKER_INVOKED line");
   // Image must be the bare-tag form, not opencode-* or hermes-*.
-  const image = a.find((x) => x.startsWith("ghcr.io/capotej/harness:"));
+  const image = a.find((x) => x.startsWith("ghcr.io/boldblackai/harness:"));
   assert.ok(image, `expected image arg in: ${a.join(" ")}`);
   assert.ok(
     !/opencode-|hermes-/.test(image),
@@ -1820,8 +1820,8 @@ test("-a short alias selects the agent (parity with --agent)", () => {
   const aLong = dockerArgs(rLong.stdout);
   // Both must produce the same hermes-prefixed image and same container
   // command shape (slice from "hermes" forward).
-  const imgShort = aShort.find((x) => x.startsWith("ghcr.io/capotej/harness:"));
-  const imgLong = aLong.find((x) => x.startsWith("ghcr.io/capotej/harness:"));
+  const imgShort = aShort.find((x) => x.startsWith("ghcr.io/boldblackai/harness:"));
+  const imgLong = aLong.find((x) => x.startsWith("ghcr.io/boldblackai/harness:"));
   assert.equal(
     imgShort,
     imgLong,
@@ -1918,7 +1918,7 @@ test("image arg immediately precedes the container command", () => {
   assert.equal(r.status, 0, r.stderr);
   const a = dockerArgs(r.stdout);
   assert.ok(a, "expected DOCKER_INVOKED line");
-  const imgIdx = a.findIndex((x) => x.startsWith("ghcr.io/capotej/harness:"));
+  const imgIdx = a.findIndex((x) => x.startsWith("ghcr.io/boldblackai/harness:"));
   assert.notEqual(imgIdx, -1, "expected an image arg");
   // The token immediately after the image must be the agent binary
   // (start of the adapter's container command).

--- a/tests/e2e/cli.test.mjs
+++ b/tests/e2e/cli.test.mjs
@@ -1820,8 +1820,12 @@ test("-a short alias selects the agent (parity with --agent)", () => {
   const aLong = dockerArgs(rLong.stdout);
   // Both must produce the same hermes-prefixed image and same container
   // command shape (slice from "hermes" forward).
-  const imgShort = aShort.find((x) => x.startsWith("ghcr.io/boldblackai/harness:"));
-  const imgLong = aLong.find((x) => x.startsWith("ghcr.io/boldblackai/harness:"));
+  const imgShort = aShort.find((x) =>
+    x.startsWith("ghcr.io/boldblackai/harness:"),
+  );
+  const imgLong = aLong.find((x) =>
+    x.startsWith("ghcr.io/boldblackai/harness:"),
+  );
   assert.equal(
     imgShort,
     imgLong,
@@ -1918,7 +1922,9 @@ test("image arg immediately precedes the container command", () => {
   assert.equal(r.status, 0, r.stderr);
   const a = dockerArgs(r.stdout);
   assert.ok(a, "expected DOCKER_INVOKED line");
-  const imgIdx = a.findIndex((x) => x.startsWith("ghcr.io/boldblackai/harness:"));
+  const imgIdx = a.findIndex((x) =>
+    x.startsWith("ghcr.io/boldblackai/harness:"),
+  );
   assert.notEqual(imgIdx, -1, "expected an image arg");
   // The token immediately after the image must be the agent binary
   // (start of the adapter's container command).


### PR DESCRIPTION
Replaces all `capotej` references with `boldblackai` across the repo.

### Changes
- **GitHub org**: `capotej` → `boldblackai` (CODEOWNERS, Makefile, links)
- **npm scope**: `@capotej/harness` → `@boldblackai/harness` (package.json, README, docs)
- **Container registry**: `ghcr.io/capotej/harness` → `ghcr.io/boldblackai/harness` (src/harness.ts, tests, docs, skills)
- **pi-coding-agent**: `@mariozechner/pi-coding-agent` → `@earendil-works/pi-coding-agent` (README, release skill)
- **Build**: Rebuilt `bin/harness.js` from updated source
- **CHANGELOG**: Left untouched (historical record)

### Files changed
23 files, 96 insertions, 96 deletions