### PR TITLE
Remove sudo and sudoers from base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && \
         jq \
         openssh-client \
         ripgrep \
-        sudo \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
         | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
@@ -28,9 +27,7 @@ RUN apt-get update && \
     && ln -s /usr/bin/fdfind /usr/local/bin/fd \
     && apt-get purge -y --auto-remove gnupg \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd -m -s /bin/bash harness \
-    && echo 'harness ALL=(root) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt, /usr/bin/dpkg' > /etc/sudoers.d/harness \
-    && chmod 0440 /etc/sudoers.d/harness
+    && useradd -m -s /bin/bash harness
 
 # Download, verify checksum, and install gh
 RUN set -eux && \


### PR DESCRIPTION
Closes #89

## Summary

Removes `sudo` and the passwordless sudoers configuration from the base Docker image.

The `/etc/sudoers.d/harness` rule (NOPASSWD for `apt-get`, `apt`, `dpkg`) never worked correctly and adds unnecessary privilege escalation surface. Agents have no legitimate need for sudo inside the container — all required packages are installed at build time, mise is the sanctioned way for agents to install packages, since it will persist restarts.

## Changes

- **Dockerfile**: Remove `sudo` from `apt-get install` and remove the two lines that created `/etc/sudoers.d/harness`

## Testing

- `pnpm test:e2e` — 97/97 pass