### PR TITLE
docs: add HARNESS_CLOUD_MODE=1 to all deployment guides

### DIFF
--- a/docs/deploying/aws.md
+++ b/docs/deploying/aws.md
@@ -184,6 +184,7 @@ Save this as `taskdef.json` (substitute `<ACCOUNT_ID>`, `<AWS_REGION>`, `<EFS_ID
     "linuxParameters": { "initProcessEnabled": true },
     "environment": [
       { "name": "TZ", "value": "America/New_York" },
+      { "name": "HARNESS_CLOUD_MODE", "value": "1" },
       { "name": "HERMES_HOME", "value": "/home/harness/.hermes" },
       { "name": "HF_HOME", "value": "/home/harness/.hermes/.cache/huggingface" }
     ],
@@ -383,6 +384,7 @@ ExecStartPre=-/usr/bin/docker rm -f hermes-claw
 ExecStart=/usr/bin/docker run --rm --name hermes-claw \
   --env-file /etc/hermes-claw.env \
   -e TZ=America/New_York \
+  -e HARNESS_CLOUD_MODE=1 \
   -e HERMES_HOME=/home/harness/.hermes \
   -e HF_HOME=/home/harness/.hermes/.cache/huggingface \
   -v /var/lib/hermes-claw:/home/harness/.hermes \

--- a/docs/deploying/fly.md
+++ b/docs/deploying/fly.md
@@ -17,6 +17,8 @@ primary_region = "iad"
 
 [env]
   TZ = "America/New_York"
+  # Signal the entrypoint to skip local defaults and auto-detect providers from API keys.
+  HARNESS_CLOUD_MODE = "1"
   # Persist the faster-whisper model cache across restarts.
   # Without this, the model re-downloads (~142 MB) on every deploy.
   HF_HOME = "/home/harness/.hermes/.cache/huggingface"

--- a/docs/deploying/k8s.md
+++ b/docs/deploying/k8s.md
@@ -108,6 +108,10 @@ spec:
           env:
             - name: TZ
               value: "America/New_York"
+            # Signal the entrypoint to skip local defaults and
+            # auto-detect providers from API keys in the env.
+            - name: HARNESS_CLOUD_MODE
+              value: "1"
             - name: HERMES_HOME
               value: "/home/harness/.hermes"
             # Persist the faster-whisper model cache across restarts.


### PR DESCRIPTION
Without this env var the entrypoints seed local defaults (e.g. LM Studio config for opencode) instead of auto-detecting providers from API keys in the environment. All cloud deployments need it.

**3 files, 8 insertions:**

- `docs/deploying/fly.md` — `[env]` section in fly.toml
- `docs/deploying/aws.md` — ECS task definition `environment[]` + EC2 systemd unit `-e` flag
- `docs/deploying/k8s.md` — Deployment `env` block