### PR TITLE
fix(docs): fix zensical build failure + add PR docs build check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,28 +9,53 @@ on:
       - ".github/workflows/docs.yml"
       - "README.md"
       - "AGENTS.md"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "zensical.toml"
+      - ".github/workflows/docs.yml"
+      - "README.md"
+      - "AGENTS.md"
   workflow_dispatch:
 permissions:
   contents: read
   pages: write
   id-token: write
-concurrency:
-  group: pages
-  cancel-in-progress: false
+
+# A docs change on a PR only needs to prove the site builds; deploying is gated
+# to non-PR events (push to main, or workflow_dispatch), preserving the original
+# deploy behavior.
 jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - run: uv tool install zensical==0.0.43
+      - name: Build site
+        run: zensical build --clean
+      # Only package the site for an actual deploy; skip on PR builds.
+      - name: Configure Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+      - name: Upload artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: site
+
   deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name != 'pull_request'
+    needs: build
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-      - run: uv tool install zensical==0.0.43
-      - run: zensical build --clean
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
-        with:
-          path: site
       - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
         id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 coverage/
 tmp/
 .pi-lens/
+site/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 **Harness** is a portable containerized environment for running coding agents. See README.md for more project details.
 
-**Documentation website:** Built with [Zensical](https://zensical.org) from `docs/`. Config in `zensical.toml`. Deploys to GitHub Pages via `.github/workflows/docs.yml`. Build locally with `pip install zensical && zensical build --clean`.
+**Documentation website:** Built with [Zensical](https://zensical.org) from `docs/`. Config in `zensical.toml`. Deploys to GitHub Pages via `.github/workflows/docs.yml`, which also runs a build-only check on PRs that touch `docs/`, `zensical.toml`, or the workflow itself (so doc build failures are caught before merge). Build locally with `pip install zensical && zensical build --clean` (CI uses `uv tool install zensical==0.0.43`).
 
 ## Commands
 
@@ -72,12 +72,13 @@ Skills mounting applies to all run modes (interactive, one-shot, `--file`). Non-
 
 ## CI/CD
 
-Four GitHub Actions workflows (`.github/workflows/`):
+The GitHub Actions workflows (`.github/workflows/`):
 
 - **`docker.yml`** — Builds and pushes multi-arch (amd64 + arm64) images to `ghcr.io/boldblackai/harness` on push to `main` and on release tags. Signs images with cosign and attests SLSA provenance. Builds base first, then opencode and hermes variants in parallel using the base image digest.
 - **`lint.yml`** — Runs `pnpm lint` on push to `main` and on PRs.
 - **`e2e.yml`** — Runs `pnpm test:e2e` on all branches and PRs. Tests against Node 22 and 24.
 - **`pr-build.yml`** — Builds all three Docker images (base + variants) on PRs using a local registry to catch build failures before merge.
+- **`docs.yml`** — Builds the Zensical docs site. On push to `main` (and `workflow_dispatch`) it deploys to GitHub Pages; on PRs that touch `docs/`, `zensical.toml`, or the workflow it runs a build-only check (the `build` job) without deploying. The `deploy` job is gated with `if: github.event_name != 'pull_request'` and the Pages artifact upload is skipped on PRs.
 
 Custom composite action: `.github/actions/attest-provenance` for SLSA provenance attestation.
 

--- a/docs/deploying/aws.md
+++ b/docs/deploying/aws.md
@@ -12,7 +12,7 @@ Two paths are documented:
 | **B. EC2 + Docker + SSM** | Single-VM hobbyist deployment. ~$13/mo on a `t4g.small`, EBS for persistence, SSM Session Manager replaces SSH (no keys, no inbound 22). Simplest possible AWS path. |
 | **C. EKS** | Already running EKS? The [Kubernetes guide](k8s.md) works on EKS unmodified — see [§ EKS](#c-eks) below for the one AWS-specific note. |
 
-As with the other deploy targets, **use the upstream signed image as-is**. Do not build a derived image — see [the fly.io guide's "Customizing the claw" section](fly.md#customizing-the-claw--dont-extend-the-image) for the rationale. AWS-equivalent injection points for both options are covered below.
+As with the other deploy targets, **use the upstream signed image as-is**. Do not build a derived image — see [the fly.io guide's "Customizing the claw" section](fly.md#customizing-the-claw-dont-extend-the-image) for the rationale. AWS-equivalent injection points for both options are covered below.
 
 ## Prerequisites
 
@@ -294,7 +294,7 @@ exit
 
 ### Fargate customization (no derived image)
 
-The fly.io guide's [`[[files]]` injection pattern](fly.md#customizing-the-claw--dont-extend-the-image) translates to two AWS techniques:
+The fly.io guide's [`[[files]]` injection pattern](fly.md#customizing-the-claw-dont-extend-the-image) translates to two AWS techniques:
 
 - **Runtime-mutable files (config, persona, persistent skills)** — seed them once on the EFS volume, then let hermes own them. Either `aws ecs execute-command` into a running task and `cp` them into place, or run a one-off Fargate task with the same EFS mount that drops files into `/etc/harness/hermes-defaults/openrouter/` before the gateway starts. The base image's `entrypoint-hermes.sh` does `cp -rn` from `/etc/harness/hermes-defaults/openrouter/` into the volume on first boot only — same first-boot-only semantics as fly.
 - **Tool wrappers / scripts (refreshed every deploy)** — bake them into a tiny sidecar layer published to ECR `FROM scratch`, mount it via a shared `bind` volume between an `initContainer`-style sidecar (using `dependsOn: { condition: COMPLETE }`) and the hermes container. Or: store them in S3 and `aws s3 sync` them in via a startup hook. Avoid `FROM ghcr.io/boldblackai/harness` — see the fly doc for why.

--- a/docs/github.md
+++ b/docs/github.md
@@ -1,5 +1,5 @@
 ---
-icon: lucide/github
+icon: material/github
 ---
 
 # GitHub authentication (`gh` CLI)


### PR DESCRIPTION
## What

Fixes the docs build failure introduced by #105 (caught only after merge: [failed run](https://github.com/boldblackai/harness/actions/runs/27872187535/job/82485749216)), and adds a PR-side docs build check so this class of failure is caught before merge.

## Root cause

`docs/github.md` declared `icon: lucide/github`, but **Lucide removed brand icons**, so `lucide/github.svg` is absent from zensical's icon set. The nav template does:

```jinja
{% include ".icons/" ~ nav_item.meta.icon ~ ".svg" %}
```

so the include threw an opaque `could not render include: error in partials/nav.html` that failed the entire build. Every other `lucide/*` icon referenced by the docs exists; only `lucide/github` was missing.

## Changes

- **`docs/github.md`** — `icon: lucide/github` → `material/github` (canonical GitHub mark). Build now exits 0.
- **`docs/deploying/aws.md`** — fix two pre-existing `anchor does not exist` warnings: links used a double hyphen (`customizing-the-claw--dont-extend-the-image`) but the heading's em-dash slugifies to a single hyphen. Build now reports **No issues found**.
- **`.github/workflows/docs.yml`** — refactor into a `build` job + gated `deploy` job:
  - `build` runs `uv tool install zensical==0.0.43` → `zensical build --clean` on **push to main, PRs, and dispatch**. On PRs it proves the site builds (the check that would have caught this bug).
  - `deploy` is gated with `if: github.event_name != 'pull_request'` + `needs: build`, so it only deploys on push-to-main / dispatch — **preserving the original deploy behavior**. Pages artifact upload skipped on PRs; `concurrency: pages` moved to the deploy job.
  - Single source of truth for the zensical version + build command (no drift between PR check and deploy). All actions pinned by SHA.
- **`.gitignore`** — ignore `site/` (zensical build output).
- **`AGENTS.md`** — document the new PR build check + CI workflow list (per the keep-docs-in-sync rule).

## Validation

- ✅ `zensical build --clean` → `Build finished`, **No issues found** (was: failure / 2 warnings)
- ✅ `actionlint` on `docs.yml` → exit 0
- ✅ `markdownlint-cli2` on changed `.md` → 0 errors