### PR TITLE
fix(docs): remove fabricated cp -rn seed mechanism from hermes entrypoint

### DIFF
--- a/docs/deploying/aws.md
+++ b/docs/deploying/aws.md
@@ -296,7 +296,7 @@ exit
 
 The fly.io guide's [`[[files]]` injection pattern](fly.md#customizing-the-claw-dont-extend-the-image) translates to two AWS techniques:
 
-- **Runtime-mutable files (config, persona, persistent skills)** — seed them once on the EFS volume, then let hermes own them. Either `aws ecs execute-command` into a running task and `cp` them into place, or run a one-off Fargate task with the same EFS mount that drops files into `/etc/harness/hermes-defaults/openrouter/` before the gateway starts. The base image's `entrypoint-hermes.sh` does `cp -rn` from `/etc/harness/hermes-defaults/openrouter/` into the volume on first boot only — same first-boot-only semantics as fly.
+- **Runtime-mutable files (config, persona, persistent skills)** — seed them once on the EFS volume, then let hermes own them. `aws ecs execute-command` into a running task and `cp` files directly into the volume path (e.g. `~/.hermes/`). The entrypoint only seeds a minimal `config.yaml` from a baked-in template on first run in local mode; there is no bulk `cp -rn` seed mechanism, so all other customizations must be placed into the volume manually.
 - **Tool wrappers / scripts (refreshed every deploy)** — bake them into a tiny sidecar layer published to ECR `FROM scratch`, mount it via a shared `bind` volume between an `initContainer`-style sidecar (using `dependsOn: { condition: COMPLETE }`) and the hermes container. Or: store them in S3 and `aws s3 sync` them in via a startup hook. Avoid `FROM ghcr.io/boldblackai/harness` — see the fly doc for why.
 
 ### Fargate teardown
@@ -386,9 +386,8 @@ dnf -y install docker
 systemctl enable --now docker
 
 # IMPORTANT: chown to 1000:1000 so the in-container harness user (uid 1000)
-# can write to the bind-mounts. Without this, entrypoint-hermes.sh's `cp -rn`
-# first-boot seed fails with "Permission denied" and the systemd unit
-# crash-loops. The four dirs mirror what the `harness` CLI bind-mounts.
+# can write to the bind-mounts. The four dirs mirror what the
+# `harness` CLI bind-mounts.
 mkdir -p /var/lib/hermes-claw \
          /var/lib/hermes-claw-config \
          /var/lib/hermes-claw-mise-data \

--- a/docs/deploying/fly.md
+++ b/docs/deploying/fly.md
@@ -107,33 +107,29 @@ When you want to give the claw extra capabilities (tool wrappers around your API
 1. The fly volume mounts on top of `/home/harness/.hermes`, which silently hides anything you `COPY` into that path on first boot.
 2. Hermes treats `config.yaml` as mutable state — TUI tweaks, model switches, and persona toggles are persisted via `save_config()`. A derived image fights that ownership.
 
-The supported pattern is to use the upstream image **unmodified** and inject your customizations via fly's [`[[files]]`](https://fly.io/docs/reference/configuration/#the-files-section) section. Files at non-volume paths get refreshed on every deploy; files seeded into `/etc/harness/hermes-defaults/openrouter/` get copied into the volume on first boot only (via `entrypoint-hermes.sh`'s `cp -rn`) so hermes' subsequent runtime config edits stick across restarts.
+The supported pattern is to use the upstream image **unmodified** and inject your customizations via fly's [`[[files]]`](https://fly.io/docs/reference/configuration/#the-files-section) section.
 
-Example — add a `crm` API wrapper script and an initial system prompt without building a new image:
+**Tool wrappers and scripts** — use non-volume paths so they're refreshed on every deploy. fly `[[files]]` preserves the local file's exec bit, so your scripts run as-is from the agent's sandbox.
+
+**Config and persona files** — the fly volume mounts over `/home/harness/.hermes`, which hides anything placed there by `[[files]]`. Instead, seed them by SSH'ing in and copying directly into the volume, or set values with `hermes config set`. The entrypoint only seeds a minimal `config.yaml` from a baked-in template on first run in local mode; there is no bulk `cp -rn` seed mechanism.
+
+Example — add a `crm` API wrapper script and seed a system prompt:
 
 ```toml
 # fly.toml — append to the example above
 
 # Tool wrappers — written to a non-volume path. Refreshed on every deploy.
-# fly [[files]] preserves the local file's exec bit, so your scripts run
-# as-is from the agent's sandbox.
 [[files]]
   guest_path = "/etc/myclaw/bin/crm"
   local_path = "bin/crm"
-
-# Initial config + persona. Upstream's hermes entrypoint copies these into
-# the volume on first boot only — after that, hermes owns its config.
-[[files]]
-  guest_path = "/etc/harness/hermes-defaults/openrouter/system-prompt.md"
-  local_path = "config/system-prompt.md"
 ```
 
-To force a refresh of `config.yaml` or `system-prompt.md` from your repo after the first boot, SSH in and delete the volume's copy before redeploying:
-
 ```bash
+# One-time: seed persona into the volume after first deploy
 fly ssh console --app my-hermes-agent-claw \
-  -C 'rm /home/harness/.hermes/system-prompt.md'
-fly deploy --app my-hermes-agent-claw
+  -C 'cat > /home/harness/.hermes/system-prompt.md <<'"'"'EOF'"'"'
+You are a helpful assistant with access to a CRM API.
+EOF'
 ```
 
 The benefits over a derived image:


### PR DESCRIPTION
entrypoint-hermes.sh has no bulk `cp -rn` seed from `/etc/harness/hermes-defaults/openrouter/`. It only seeds `config.yaml` from a single baked-in template on first run in local mode.

**Fixed:**
- `docs/deploying/aws.md` line ~299 — removed fake `hermes-defaults/openrouter/` path and `cp -rn` claim; now tells users to `aws ecs execute-command` in and `cp` directly into the volume
- `docs/deploying/aws.md` line ~389 — removed misleading comment about `cp -rn` permission-denied crash-loops
- `docs/deploying/fly.md` line ~110 — removed fabricated first-boot seed explanation; split into accurate guidance for scripts (use `[[files]]` on non-volume paths) vs config/persona (SSH in and write directly)
- `docs/deploying/fly.md` line ~127 — removed fake `[[files]]` example targeting the non-existent defaults directory; replaced with `fly ssh console` one-liner for seeding persona