### PR TITLE
chore: bump pnpm 10.33.2 → 11.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV PNPM_HOME=/usr/local/share/pnpm
 ENV PNPM_MINIMUM_RELEASE_AGE=10080
 ENV PATH=$PNPM_HOME:$PATH
 
-RUN corepack enable && corepack prepare pnpm@10.33.2 --activate && \
+RUN corepack enable && corepack prepare pnpm@11.9.0 --activate && \
     pnpm install -g @earendil-works/pi-coding-agent@0.79.2 && \
     pnpm store prune && \
     rm -rf ~/.cache/pnpm ~/.npm && \

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/boldblackai/harness.git"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.9.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bumps pnpm from 10.33.2 to 11.9.0 (released June 23, past 7-day cooldown).

- `Dockerfile` L52: `corepack prepare pnpm@11.9.0 --activate`
- `package.json` L13: `"packageManager": "pnpm@11.9.0"`