### PR TITLE
Pre-build web UI in Docker image

### DIFF
--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -101,7 +101,7 @@ RUN apt-get update && \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \
     && cd /opt/hermes-agent/web && npm install && npm run build && cd / \
     && chown -R harness:harness /opt/hermes-agent \
-    && rm -rf /opt/hermes-agent/.git /root/.cache/uv \
+    && rm -rf /opt/hermes-agent/.git /opt/hermes-agent/web/node_modules /root/.cache/uv \
     && rm -rf /var/lib/apt/lists/*
 
 COPY hermes/local.yaml /etc/harness/hermes-local.yaml

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -99,6 +99,7 @@ RUN apt-get update && \
     && uv venv /opt/hermes-agent/venv --python python3 \
     && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp,web,pty,matrix,bedrock] "python-telegram-bot==22.6" "faster-whisper==1.2.1" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \
+    && cd /opt/hermes-agent/web && npm install && npm run build && cd / \
     && chown -R harness:harness /opt/hermes-agent \
     && rm -rf /opt/hermes-agent/.git /root/.cache/uv \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -97,7 +97,7 @@ RUN apt-get update && \
         python3-dev build-essential git libffi-dev libolm-dev \
     && git clone --depth 1 --branch v2026.7.7.2 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
     && uv venv /opt/hermes-agent/venv --python python3 \
-    && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp,web,pty,matrix,bedrock] "python-telegram-bot==22.6" "faster-whisper==1.2.1" \
+    && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp,web,pty,matrix,bedrock,slack] "python-telegram-bot==22.6" "faster-whisper==1.2.1" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \
     && cd /opt/hermes-agent/web && npm install && npm run build && cd / \
     && chown -R harness:harness /opt/hermes-agent \
@@ -105,6 +105,8 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 COPY hermes/local.yaml /etc/harness/hermes-local.yaml
+
+ENV HERMES_DISABLE_LAZY_INSTALLS=1
 
 COPY entrypoint-hermes.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## Summary

Builds the dashboard frontend during image build instead of at runtime.

Adds `cd /opt/hermes-agent/web && npm install && npm run build` to the
hermes Dockerfile, right after hermes-agent is installed and before
ownership is set and artifacts are cleaned up.

The Vite build outputs to `hermes_cli/web_dist/`, which is the sentinel
directory the staleness check in hermes-agent looks at — so once
pre-built, the runtime check correctly skips the rebuild.

Closes #120

## Test

`make image-hermes` — image should build successfully with the web
assets baked in. Running `hermes dashboard` should serve the pre-built
UI without triggering a frontend build.