### PR TITLE
deps: bump pinned dependencies to 7-day cooldown-compliant latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:stable-slim@sha256:5012d0517aa0075a7150a45aae67586641e898913b7af3b08228108565b5f90c
+FROM debian:stable-slim@sha256:2df2bd18394a8ad5a46cf5d77bfca9de0df479d485987330d1ce017c904b00e4
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG GH_VERSION="2.95.0"
+ARG GH_VERSION="2.96.0"
 ARG MISE_VERSION="2026.4.23"
 ARG TARGETARCH
 
@@ -49,8 +49,8 @@ ENV PNPM_HOME=/usr/local/share/pnpm
 ENV PNPM_MINIMUM_RELEASE_AGE=10080
 ENV PATH=$PNPM_HOME:$PATH
 
-RUN corepack enable && corepack prepare pnpm@10.33.2 --activate && \
-    pnpm install -g @earendil-works/pi-coding-agent@0.79.2 && \
+RUN corepack enable && corepack prepare pnpm@10.34.4 --activate && \
+    pnpm install -g @earendil-works/pi-coding-agent@0.80.3 && \
     pnpm store prune && \
     rm -rf ~/.cache/pnpm ~/.npm && \
     mkdir -p /etc/harness/pi-defaults && \

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/boldblackai/harness:latest
-ARG UV_DIGEST=sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6
+ARG UV_DIGEST=sha256:3d868e555f8f1dbc324afa005066cd11e1053fc4743b9808ca8025283e65efa5
 
 FROM ghcr.io/astral-sh/uv@${UV_DIGEST} AS uv-src
 
@@ -7,8 +7,8 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-ARG UV_VERSION=0.11.19
-ARG UV_DIGEST=sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6
+ARG UV_VERSION=0.11.26
+ARG UV_DIGEST=sha256:3d868e555f8f1dbc324afa005066cd11e1053fc4743b9808ca8025283e65efa5
 ARG COSIGN_VERSION=3.1.1
 ARG COSIGN_AMD64_SHA256=ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc
 ARG COSIGN_ARM64_SHA256=2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11
@@ -85,7 +85,7 @@ RUN set -eux && \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         python3 python3-dev python3-venv build-essential git libffi-dev libolm-dev \
-    && git clone --depth 1 --branch v2026.6.19 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
+    && git clone --depth 1 --branch v2026.7.1 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
     && uv venv /opt/hermes-agent/venv --python python3 \
     && VIRTUAL_ENV=/opt/hermes-agent/venv uv pip install --no-cache-dir --exclude-newer="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')" -e /opt/hermes-agent[mcp,web,pty,matrix,bedrock] "python-telegram-bot==22.6" "faster-whisper==1.2.1" \
     && ln -sf /opt/hermes-agent/venv/bin/hermes /usr/local/bin/hermes \

--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-RUN pnpm install -g opencode-ai@1.15.10 && \
+RUN pnpm install -g opencode-ai@1.17.13 && \
     cd $(pnpm root -g)/opencode-ai && node postinstall.mjs && \
     pnpm store prune && \
     rm -rf ~/.cache/pnpm ~/.npm

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/boldblackai/harness.git"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@10.34.4",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Ran the `check-deps` skill against all pinned Dockerfile dependencies. This PR bumps each outdated dep to the **newest release that satisfies the project's 7-day cooldown policy** (cutoff: **2026-07-05**).

## Results

| Dependency | Pinned | Latest (age) | Target in this PR | Status |
|---|---|---|---|---|
| `@earendil-works/pi-coding-agent` | 0.79.2 | 0.80.6 (3d) | **0.80.3** | outdated ⬆ |
| `opencode-ai` | 1.15.10 | 1.17.18 (3d) | **1.17.13** | outdated ⬆ |
| `hermes-agent` | v2026.6.19 | v2026.7.7.2 (4d) | **v2026.7.1** | outdated ⬆ |
| `gh` | 2.95.0 | 2.96.0 (10d) | **2.96.0** | outdated ⬆ |
| `cosign` | 3.1.1 | 3.1.1 | — | ✅ up to date |
| `uv` | 0.11.19 | 0.11.28 (5d) | **0.11.26** + digest | outdated ⬆ |
| `pnpm` | 10.33.2 | 11.12.0 (1d) | **10.34.4** | outdated ⬆ |
| `debian:stable-slim` | `5012d051…` | `2df2bd18…` | **digest refresh** | outdated ⬆ |

🕐 = on cooldown (published < 7 days ago). For those, the absolute latest is held back and the newest cooldown-compliant release is used instead.

## Changes

- **Dockerfile**
  - `debian:stable-slim` base image digest refresh (not subject to cooldown)
  - `gh` 2.95.0 → 2.96.0
  - `pnpm` 10.33.2 → 10.34.4 (`corepack prepare`)
  - `@earendil-works/pi-coding-agent` 0.79.2 → 0.80.3
- **package.json** — `packageManager` pnpm 10.33.2 → 10.34.4 (kept in sync with the Dockerfile pin)
- **Dockerfile.opencode** — `opencode-ai` 1.15.10 → 1.17.13
- **Dockerfile.hermes**
  - `uv` 0.11.19 → 0.11.26 with new multi-arch index digest `sha256:3d868e55…` (both `UV_VERSION` and `UV_DIGEST`; digest verified against the `astral-sh/uv` attestation endpoint — 2 attestations present, so the SLSA provenance step will pass)
  - `hermes-agent` v2026.6.19 → v2026.7.1

## Notes

- **pnpm**: stayed in-major (10.34.4, June 18) rather than jumping to the 11.x line. `11.10.0` (July 4) is also off-cooldown if a major bump is wanted — happy to switch.
- **cosign**: already current at 3.1.1, no change.
- **hermes-agent**: still installed via `git clone`, so uv's `--exclude-newer` cooldown does not cover it; the manual tag date check was applied (v2026.7.1 = July 1, 11 days old).

🤖 Generated as part of a `check-deps` skill run.