### PR TITLE
fix: refuse to run from $HOME unless --mount-entire-home is passed (#113)

### DIFF
--- a/src/harness.ts
+++ b/src/harness.ts
@@ -21,6 +21,7 @@ interface Args extends ParsedArgs {
   local: boolean;
   skills?: boolean;
   "context-files"?: boolean;
+  "mount-entire-home"?: boolean;
   "env-file"?: string;
   e?: string;
   file?: string;
@@ -516,6 +517,7 @@ Options:
   --no-context-files     Disable mounting global context files (~/.agents/AGENTS.md, ~/.claude/CLAUDE.md); alias -nc
   --ephemeral            Disable session persistence (implied by -p and piped stdin)
   --local                Force local mode even with -e (use LM Studio / local defaults)
+  --mount-entire-home    Allow running from your home directory (mounts all of $HOME as the workspace)
   -h, --help             Show this help message
 
 Environment variables:
@@ -560,7 +562,7 @@ function getImage(agent: string): string {
 }
 
 const MINIMIST_OPTS = {
-  boolean: ["help", "h", "ephemeral", "local"],
+  boolean: ["help", "h", "ephemeral", "local", "mount-entire-home"],
   string: [
     "env-file",
     "e",
@@ -621,6 +623,7 @@ if (argv.help) {
 const noVerify = argv.verify === false;
 const noSkills = argv.skills === false;
 const noContextFiles = argv["context-files"] === false;
+const mountEntireHome = argv["mount-entire-home"] === true;
 const localMode = argv.local;
 const envFilePath = argv["env-file"] || null;
 const fileArg = argv.file || null;
@@ -653,6 +656,22 @@ if (fileArg && !fs.existsSync(fileArg)) {
 if (fileArg && fs.statSync(fileArg).isDirectory()) {
   console.error(`harness: --file requires a file, not a directory: ${fileArg}`);
   process.exit(1);
+}
+
+// Guard against accidentally mounting the entire home directory as the
+// workspace. Running from $HOME mounts all dotfiles/credentials into the
+// container and gives the agent a noisy, unfocused workspace. Only relevant
+// when the cwd is what gets mounted (not --file mode). --mount-entire-home
+// is the explicit opt-in for the rare case where this is intended.
+if (!fileArg && !mountEntireHome) {
+  const resolvedCwd = fs.realpathSync(workspace);
+  const resolvedHome = fs.realpathSync(os.homedir());
+  if (resolvedCwd === resolvedHome) {
+    console.error(
+      `harness: refusing to run from your home directory (${resolvedHome}).\nThis would mount your entire home into the container, exposing dotfiles and credentials.\nPass --mount-entire-home to proceed, or cd into a project directory first.`,
+    );
+    process.exit(1);
+  }
 }
 
 const volumeArgList: string[] = Array.isArray(argv.volumes)

--- a/tests/e2e/parsing.test.mjs
+++ b/tests/e2e/parsing.test.mjs
@@ -233,3 +233,61 @@ test("docker invocation always includes hardening flags", () => {
   assert.notEqual(wIdx, -1);
   assert.equal(a[wIdx + 1], "/workspace");
 });
+
+// ---- home-directory guard (issue #113) -------------------------------------
+//
+// Running harness from $HOME mounts the entire home dir as /workspace, exposing
+// dotfiles/credentials. We refuse unless --mount-entire-home is passed. Tests
+// force cwd === home by pointing HOME at WORK_DIR (runCli always runs in
+// WORK_DIR, and os.homedir() honors $HOME on POSIX).
+
+test("running from $HOME errors without --mount-entire-home", () => {
+  const r = runCli(["-p", "noop"], { extraEnv: { HOME: WORK_DIR } });
+  assert.notEqual(r.status, 0, "should exit non-zero when cwd is home");
+  assert.match(r.stderr, /home directory/);
+  assert.match(r.stderr, /--mount-entire-home/);
+  // Must bail out before invoking the container runtime.
+  assert.equal(
+    dockerArgs(r.stdout),
+    null,
+    `docker must not be invoked when refusing to run from home: ${r.stdout}`,
+  );
+});
+
+test("--mount-entire-home allows running from $HOME and mounts it", () => {
+  const r = runCli(["--mount-entire-home", "-p", "noop"], {
+    extraEnv: { HOME: WORK_DIR },
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.doesNotMatch(r.stderr, /home directory/);
+  // --mount-entire-home must not be reported as an unrecognized flag.
+  assert.doesNotMatch(r.stderr, /unrecognized flag/);
+  const a = dockerArgs(r.stdout);
+  assert.ok(a, "expected DOCKER_INVOKED line");
+  assert.ok(
+    a.some((arg) => arg === `${WORK_DIR}:/workspace`),
+    `expected home mounted as workspace in: ${a.join(" ")}`,
+  );
+});
+
+test("--file mode from $HOME is allowed (cwd is not mounted)", () => {
+  // In --file mode only the single file is mounted, not the cwd, so the
+  // home-directory footgun doesn't apply and the guard must not fire.
+  const r = runCli(["-f", SAMPLE_FILE, "-p", "noop"], {
+    extraEnv: { HOME: WORK_DIR },
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.doesNotMatch(r.stderr, /home directory/);
+  const a = dockerArgs(r.stdout);
+  assert.ok(a, "expected DOCKER_INVOKED line");
+  assert.ok(
+    a.some((arg) => arg.endsWith(":/workspace/script.py")),
+    `expected single-file mount in: ${a.join(" ")}`,
+  );
+});
+
+test("--help documents --mount-entire-home", () => {
+  const r = runCli(["--help"]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /--mount-entire-home/);
+});

--- a/tests/e2e/persistence.test.mjs
+++ b/tests/e2e/persistence.test.mjs
@@ -367,17 +367,24 @@ test("normalizeCwd: CWD is exactly home dir → uses _home", () => {
   const xdgData = path.join(tmp, "xdg-data");
   fs.mkdirSync(xdgData, { recursive: true });
   try {
-    const r = spawnSync("script", ["-qfec", `node ${CLI}`, "/dev/null"], {
-      cwd: homeDir,
-      env: {
-        ...process.env,
-        PATH: `${SHIM_DIR}:${process.env.PATH}`,
-        HARNESS_IMAGE_TAG: "test-tag",
-        HOME: homeDir,
-        XDG_DATA_HOME: xdgData,
+    // Running from $HOME is gated by the home-directory guard (issue #113);
+    // pass --mount-entire-home to opt in and reach the persistence path that
+    // exercises the _home normalization branch.
+    const r = spawnSync(
+      "script",
+      ["-qfec", `node ${CLI} --mount-entire-home`, "/dev/null"],
+      {
+        cwd: homeDir,
+        env: {
+          ...process.env,
+          PATH: `${SHIM_DIR}:${process.env.PATH}`,
+          HARNESS_IMAGE_TAG: "test-tag",
+          HOME: homeDir,
+          XDG_DATA_HOME: xdgData,
+        },
+        encoding: "utf8",
       },
-      encoding: "utf8",
-    });
+    );
     assert.equal(r.status, 0, r.stderr);
     assert.equal(
       fs.existsSync(path.join(xdgData, "harness", "_home", "pi")),


### PR DESCRIPTION
## Summary

Closes #113.

Running `harness` from the home directory silently mounts **all of `$HOME`** into the container at `/workspace` — exposing dotfiles, credentials, and SSH keys to the agent, and giving it a noisy, unfocused workspace.

## Fix

Add a guard right after arg validation: if the resolved cwd equals the resolved home directory, exit with a clear error and instructions. A new **`--mount-entire-home`** flag opts back in for the rare case where mounting all of `$HOME` is genuinely intended.

```
harness: refusing to run from your home directory (/home/harness).
This would mount your entire home into the container, exposing dotfiles and credentials.
Pass --mount-entire-home to proceed, or cd into a project directory first.
```

## Scope / edge cases

- **Only fires when the cwd is what gets mounted.** `--file` mode mounts a single file (not the cwd), so it's unaffected — there's a test locking that.
- Paths are compared via `fs.realpathSync`, so a symlinked `$HOME` still matches.
- `--mount-entire-home` is registered as a boolean flag, so it isn't reported as an unrecognized flag.

## Tests

4 new e2e cases in `parsing.test.mjs`:
- refuses to run from `$HOME` (exits non-zero, clear error, **never invokes the runtime**)
- `--mount-entire-home` opts in and mounts home as the workspace
- `--file` mode from `$HOME` is allowed
- `--help` documents the flag

Also updated the existing `normalizeCwd … _home` persistence test to pass `--mount-entire-home`, since it deliberately runs from home to exercise the `_home` key — the behavior it locks is unchanged, it just now goes through the opt-in.

Full suite **115 passing / 0 failing** locally (`pnpm test:e2e`); `biome check .` clean, `pnpm build` green.

cc @capotej
