### PR TITLE
fix: apple host.docker.internal DNS hint + Hermes context mount (#118, #119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,14 @@ cpus = 8
 memory = "4g"
 ```
 
+**Container → host (`host.docker.internal`).** Docker Desktop provides `host.docker.internal` automatically; Apple's `container` CLI does not. Local-mode agents (pi, opencode, hermes without `-e`) reach LM Studio and other host services via that hostname. One-time setup on Apple Silicon (requires administrator):
+
+```bash
+sudo container system dns create host.docker.internal --localhost 203.0.113.113
+```
+
+Harness prints a reminder on `HARNESS_CONTAINER_RUNTIME=apple` runs if this mapping is missing. See [apple/container — access a host service](https://github.com/apple/container/blob/main/docs/how-to.md#access-a-host-service-from-a-container).
+
 ### Agent-specific behavior
 
 - **pi** — `-m` is passed straight to the binary as `--model`.

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -243,11 +243,7 @@ class AppleContainerRuntime implements ContainerRuntime {
     }
     if (!appleHostDockerInternalDnsConfigured()) {
       console.error(
-        `harness: ${HOST_DOCKER_INTERNAL} is not configured for Apple's container runtime.\n` +
-          "Local services on the Mac (e.g. LM Studio on :1234) will not be reachable from the container.\n" +
-          "One-time fix (requires administrator):\n" +
-          `  sudo container system dns create ${HOST_DOCKER_INTERNAL} --localhost ${APPLE_HOST_LOCALHOST_IP}\n` +
-          "See https://github.com/apple/container/blob/main/docs/how-to.md#access-a-host-service-from-a-container",
+        `harness: ${HOST_DOCKER_INTERNAL} is not configured for Apple's container runtime.\nLocal services on the Mac (e.g. LM Studio on :1234) will not be reachable from the container.\nOne-time fix (requires administrator):\n  sudo container system dns create ${HOST_DOCKER_INTERNAL} --localhost ${APPLE_HOST_LOCALHOST_IP}\nSee https://github.com/apple/container/blob/main/docs/how-to.md#access-a-host-service-from-a-container`,
       );
     }
   }

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -143,6 +143,25 @@ class DockerRuntime implements ContainerRuntime {
   }
 }
 
+const HOST_DOCKER_INTERNAL = "host.docker.internal";
+// Documentation-range IP apple/container uses to route a custom DNS name to the
+// host's localhost. See apple/container how-to: "Access a host service from a
+// container".
+const APPLE_HOST_LOCALHOST_IP = "203.0.113.113";
+
+function appleHostDockerInternalDnsConfigured(): boolean {
+  try {
+    const out = execFileSync("container", ["system", "dns", "list"], {
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+    }).toString();
+    return out.includes(HOST_DOCKER_INTERNAL);
+  } catch {
+    // If we cannot inspect DNS config, do not block the run.
+    return true;
+  }
+}
+
 class AppleContainerRuntime implements ContainerRuntime {
   binary(): string {
     return "container";
@@ -221,6 +240,15 @@ class AppleContainerRuntime implements ContainerRuntime {
         "harness: HARNESS_CONTAINER_RUNTIME=apple requires the `container` CLI (Apple container, v1.0.0+). Install from https://github.com/apple/container/releases and run `container system start`, or unset HARNESS_CONTAINER_RUNTIME to use docker.",
       );
       process.exit(1);
+    }
+    if (!appleHostDockerInternalDnsConfigured()) {
+      console.error(
+        `harness: ${HOST_DOCKER_INTERNAL} is not configured for Apple's container runtime.\n` +
+          "Local services on the Mac (e.g. LM Studio on :1234) will not be reachable from the container.\n" +
+          "One-time fix (requires administrator):\n" +
+          `  sudo container system dns create ${HOST_DOCKER_INTERNAL} --localhost ${APPLE_HOST_LOCALHOST_IP}\n` +
+          "See https://github.com/apple/container/blob/main/docs/how-to.md#access-a-host-service-from-a-container",
+      );
     }
   }
 }
@@ -324,7 +352,9 @@ class HermesAdapter implements AgentAdapter {
   }
 
   contextDir(): string {
-    return "/home/harness/.hermes";
+    // Hermes reads AGENTS.md / CLAUDE.md from the project cwd only, not
+    // ~/.hermes/. Mount global context files into /workspace so they apply.
+    return "/workspace";
   }
 }
 

--- a/tests/e2e/helpers.mjs
+++ b/tests/e2e/helpers.mjs
@@ -108,10 +108,18 @@ export function normalizeCwd(cwd, home) {
   return normalized;
 }
 
-/** Returns true if the `script` command is available (needed for PTY tests). */
+/** Returns true if util-linux `script -qfec` works (needed for PTY tests). */
 export function hasScript() {
+  if (
+    spawnSync("sh", ["-c", "command -v script"], { encoding: "utf8" }).status !==
+    0
+  ) {
+    return false;
+  }
+  // macOS ships bsd `script` without `-f`; CI uses util-linux. Probe the flag
+  // we actually use instead of only checking PATH.
   return (
-    spawnSync("sh", ["-c", "command -v script"], { encoding: "utf8" })
+    spawnSync("script", ["-qfec", "true", "/dev/null"], { encoding: "utf8" })
       .status === 0
   );
 }

--- a/tests/e2e/helpers.mjs
+++ b/tests/e2e/helpers.mjs
@@ -111,8 +111,8 @@ export function normalizeCwd(cwd, home) {
 /** Returns true if util-linux `script -qfec` works (needed for PTY tests). */
 export function hasScript() {
   if (
-    spawnSync("sh", ["-c", "command -v script"], { encoding: "utf8" }).status !==
-    0
+    spawnSync("sh", ["-c", "command -v script"], { encoding: "utf8" })
+      .status !== 0
   ) {
     return false;
   }

--- a/tests/e2e/mounts.test.mjs
+++ b/tests/e2e/mounts.test.mjs
@@ -1017,8 +1017,8 @@ test("global ~/.agents/AGENTS.md is mounted to the hermes context path", () => {
     const a = dockerArgs(r.stdout);
     assert.ok(a, "expected DOCKER_INVOKED line");
     assert.ok(
-      a.some((arg) => arg.endsWith(":/home/harness/.hermes/AGENTS.md")),
-      `expected AGENTS.md mount at hermes path in: ${a.join(" ")}`,
+      a.some((arg) => arg.endsWith(":/workspace/AGENTS.md")),
+      `expected AGENTS.md mount at hermes workspace path in: ${a.join(" ")}`,
     );
   } finally {
     cleanup();

--- a/tests/e2e/runtime.test.mjs
+++ b/tests/e2e/runtime.test.mjs
@@ -275,12 +275,21 @@ test("apple runtime with `container` absent from PATH exits with the install hin
     path.join(os.tmpdir(), "harness-nodocker-"),
   );
   makeDockerShim(dockerOnlyDir);
+  const pathWithoutContainer = process.env.PATH.split(path.delimiter)
+    .filter((dir) => {
+      try {
+        return !fs.existsSync(path.join(dir, "container"));
+      } catch {
+        return true;
+      }
+    })
+    .join(path.delimiter);
   try {
     const r = spawnSync("node", [CLI, "-p", "noop"], {
       cwd: WORK_DIR,
       env: {
         ...process.env,
-        PATH: `${dockerOnlyDir}:${process.env.PATH}`,
+        PATH: `${dockerOnlyDir}:${pathWithoutContainer}`,
         HARNESS_IMAGE_TAG: "test-tag",
         HARNESS_CONTAINER_RUNTIME: "apple",
       },
@@ -300,6 +309,24 @@ test("apple runtime with `container` absent from PATH exits with the install hin
   } finally {
     fs.rmSync(dockerOnlyDir, { recursive: true, force: true });
   }
+});
+
+test("HARNESS_CONTAINER_RUNTIME=apple warns when host.docker.internal DNS is missing", () => {
+  const which = spawnSync("sh", ["-c", "command -v container"], {
+    encoding: "utf8",
+  });
+  if (which.status !== 0) return;
+  const list = spawnSync("container", ["system", "dns", "list"], {
+    encoding: "utf8",
+  });
+  if (list.status !== 0 || list.stdout.includes("host.docker.internal")) return;
+
+  const r = runCli(["-p", "noop"], {
+    extraEnv: { HARNESS_CONTAINER_RUNTIME: "apple" },
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stderr, /host\.docker\.internal/);
+  assert.match(r.stderr, /container system dns create/);
 });
 
 // ---- cosign cache is runtime-agnostic -------------------------------------


### PR DESCRIPTION
## Summary

- **#118** — On `HARNESS_CONTAINER_RUNTIME=apple`, harness checks `container system dns list` and prints a one-time setup command when `host.docker.internal` is missing (LM Studio / local gateway reachability). Documents the Apple-recommended `container system dns create … --localhost 203.0.113.113` flow in README.
- **#119** — `HermesAdapter.contextDir()` now returns `/workspace` so globally mounted `AGENTS.md` / `CLAUDE.md` land where Hermes actually reads project context (not `~/.hermes`).
- E2e: skip PTY tests when macOS `script` lacks util-linux `-qfec`; fix “container absent from PATH” test when real `container` is on PATH; conditional test for the DNS warning.

## Test plan

- [x] `pnpm build`
- [x] `node --test tests/e2e/runtime.test.mjs` — 15/15 on macOS arm64
- [x] Hermes context mount test passes (`:/workspace/AGENTS.md`)
- [ ] CI e2e (Linux — full suite including PTY)
- [ ] Operator one-time on Mac (outside harness): `sudo container system dns create host.docker.internal --localhost 203.0.113.113`

Closes #118, closes #119.

cc @capotej

Made with [Cursor](https://cursor.com)