### PR TITLE
feat(hermes): add Chromium system deps for Playwright browsers

### DIFF
--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -104,6 +104,34 @@ RUN apt-get update && \
     && rm -rf /opt/hermes-agent/.git /opt/hermes-agent/web/node_modules /root/.cache/uv \
     && rm -rf /var/lib/apt/lists/*
 
+# Chromium shared libraries required to run Playwright browsers (the default
+# browser for the @playwright/mcp server). Minimum deps for Chromium only;
+# Firefox/WebKit would need additional GTK/GStreamer libs. See issue #128.
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libglib2.0-0t64 \
+        libnspr4 \
+        libnss3 \
+        libatk1.0-0t64 \
+        libatk-bridge2.0-0t64 \
+        libdbus-1-3 \
+        libcups2t64 \
+        libxcb1 \
+        libxkbcommon0 \
+        libasound2t64 \
+        libgbm1 \
+        libx11-6 \
+        libxext-6 \
+        libcairo2 \
+        libpango-1.0-0 \
+        libxcomposite1 \
+        libxdamage1 \
+        libxfixes3 \
+        libxrandr2 \
+        libatspi2.0-0t64 \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY hermes/local.yaml /etc/harness/hermes-local.yaml
 
 ENV HERMES_DISABLE_LAZY_INSTALLS=1

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -122,7 +122,7 @@ RUN apt-get update && \
         libasound2t64 \
         libgbm1 \
         libx11-6 \
-        libxext-6 \
+        libxext6 \
         libcairo2 \
         libpango-1.0-0 \
         libxcomposite1 \


### PR DESCRIPTION
## Summary

The Hermes image is missing the shared libraries required to run any Playwright browser (Chromium, Firefox, WebKit). All three fail with missing `.so` errors, and the `harness` user has no root access, so deps cannot be installed at runtime. This blocks the `@playwright/mcp` server from working out of the box.

This PR adds the **minimum Chromium shared libraries** (Chromium is the default Playwright MCP browser) to `Dockerfile.hermes` as a dedicated apt layer.

Added packages:
`libglib2.0-0t64`, `libnspr4`, `libnss3`, `libatk1.0-0t64`, `libatk-bridge2.0-0t64`, `libdbus-1-3`, `libcups2t64`, `libxcb1`, `libxkbcommon0`, `libasound2t64`, `libgbm1`, `libx11-6`, `libxext-6`, `libcairo2`, `libpango-1.0-0`, `libxcomposite1`, `libxdamage1`, `libxfixes3`, `libxrandr2`, `libatspi2.0-0t64`

These are the minimum deps for Chromium only. Firefox/WebKit would require additional GTK/GStreamer libs if multi-browser support is desired later.

## Test Plan

- [ ] `make image-hermes` builds successfully
- [ ] `ldd ~/.cache/ms-playwright/chromium-*/chrome-linux/chrome | grep "not found"` returns empty
- [ ] `@playwright/mcp` server launches and can drive a browser

Closes #128