### PR TITLE
feat: npm trusted publishing (OIDC) + release skill update

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -15,18 +15,17 @@ Automates the full release pipeline: pre-flight checks → version bump → CHAN
 
 ## Step 1: Pre-flight checks (abort on failure)
 
-**Main bookmark is up to date** — Verify that the local `main` bookmark and `main@origin` point to the same commit. In jj, remote bookmarks use `<bookmark>@<remote>` syntax (not `origin/<bookmark>`). Run:
+**Ensure working from latest main** — Fetch latest and verify local main matches remote:
 
 ```bash
-jj log -r "main" --no-graph -T 'commit_id ++ "\n"'
-jj log -r "main@origin" --no-graph -T 'commit_id ++ "\n"'
+git fetch origin main
+git checkout main
+git pull --ff-only origin main
 ```
 
-If they differ, there are unpushed commits on `main`. Inform the user:
+If `git pull --ff-only` fails (local main has diverged), inform the user and abort.
 
-> "Aborting: local main is ahead of main@origin. Push your commits first with `jj git push`."
-
-**Clean working state** — Run `jj status`. If there are uncommitted changes beyond what you're about to create (`package.json` + `CHANGELOG.md` + deploy guides), warn the user and ask whether to proceed.
+**Clean working state** — Run `git status`. If there are uncommitted changes beyond what you're about to create (`package.json` + `CHANGELOG.md` + deploy guides), warn the user and ask whether to proceed.
 
 **README is up to date** — Read `README.md` and the commits since the last tag (collected in Step 3). Check whether any commit introduces new CLI flags, options, agents, or user-visible behavior that isn't reflected in `README.md`. If gaps are found, list them and ask the user to update `README.md` before continuing:
 
@@ -124,7 +123,7 @@ Omit `### Dependency Updates` and `### Upstream Release Notes` entirely if there
 
 ## Step 5: Bump version in package.json
 
-Edit the `version` field directly in `package.json`. Do not use `npm version` — it creates git commits automatically and would interfere with the jj workflow.
+Edit the `version` field directly in `package.json`. Do not use `npm version` — it creates git commits and tags automatically and would interfere with the release workflow.
 
 ## Step 5b: Update hermes image tag in deploy guides
 
@@ -150,34 +149,28 @@ pnpm build
 
 Stop if this fails.
 
-## Step 7: Commit the release and create a branch
+## Step 7: Create release branch and commit
 
-In jj, file changes are automatically snapshotted in the working-copy commit. Describe it and move to a new empty commit:
-
-```bash
-jj describe -m "release v<version>"
-jj new
-```
-
-Create a release branch pointing to the release commit (do NOT move main):
+Create a release branch from main and commit all release changes:
 
 ```bash
-jj bookmark set release/v<version> -r @-
+git checkout -b release/v<version>
+git add package.json CHANGELOG.md docs/
+git commit -m "release v<version>"
 ```
 
 ## Step 8: Push branch and open release PR
 
-Push the release branch to the fork:
+Ensure a fork remote exists (for the agent's bot account):
 
 ```bash
-jj git push --bookmark release/v<version> --remote fork
+git remote add fork https://github.com/BoldBlackBot/harness.git 2>/dev/null || true
 ```
 
-If the fork remote doesn't exist, create it first:
+Push the release branch:
 
 ```bash
-git remote add fork https://github.com/BoldBlackBot/harness.git
-jj git push --bookmark release/v<version> --remote fork
+git push -u fork release/v<version>
 ```
 
 Open the PR:
@@ -209,8 +202,7 @@ After the user confirms the PR is merged, fetch the latest main and tag the merg
 
 ```bash
 git fetch origin main
-MERGE_SHA=$(git rev-parse origin/main)
-git tag v<version> $MERGE_SHA
+git tag v<version> origin/main
 git push origin v<version>
 ```
 

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -5,9 +5,11 @@ description: Automate releasing the harness npm package. Use this skill whenever
 
 # Release Skill for `harness`
 
-Automates the full release pipeline: pre-flight checks → version bump → CHANGELOG → build → commit/push main → tag (triggers npm publish via OIDC trusted publishing) → verify npm → GitHub release → verify CI.
+Automates the full release pipeline: pre-flight checks → version bump → CHANGELOG → build → open release PR → (user merges) → tag (triggers npm publish via OIDC trusted publishing) → verify npm → GitHub release → verify CI.
 
-> **npm publishing is fully automated via [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC).** Pushing a `v*` tag triggers `.github/workflows/publish.yml`, which authenticates to npm via a short-lived OIDC token — no long-lived npm token, no manual `npm publish`, no OTP. Provenance attestations are generated automatically. The trust boundary is "can push to main" = "can release."
+> **npm publishing is fully automated via [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC).** Pushing a `v*` tag triggers `.github/workflows/publish.yml`, which authenticates to npm via a short-lived OIDC token — no long-lived npm token, no manual `npm publish`, no OTP. Provenance attestations are generated automatically.
+>
+> **Release model:** The agent prepares the release commit (version bump + CHANGELOG + deploy guide tags) and opens a PR. A maintainer reviews and merges. The agent then tags the merge commit, which triggers the automated publish. The trust boundary is "can merge a PR to main" = "can release."
 >
 > **Prerequisite (one-time, manual on npmjs.com):** Configure the trusted publisher for `@boldblackai/harness` under Settings → Trusted Publisher → GitHub Actions: org=`boldblackai`, repo=`harness`, workflow filename=`publish.yml`. Then under Settings → Publishing access, select "Require two-factor authentication and disallow tokens" (recommended) — OIDC publishes are unaffected by this setting.
 
@@ -24,7 +26,7 @@ If they differ, there are unpushed commits on `main`. Inform the user:
 
 > "Aborting: local main is ahead of main@origin. Push your commits first with `jj git push`."
 
-**Clean working state** — Run `jj status`. If there are uncommitted changes beyond what you're about to create (`package.json` + `CHANGELOG.md`), warn the user and ask whether to proceed.
+**Clean working state** — Run `jj status`. If there are uncommitted changes beyond what you're about to create (`package.json` + `CHANGELOG.md` + deploy guides), warn the user and ask whether to proceed.
 
 **README is up to date** — Read `README.md` and the commits since the last tag (collected in Step 3). Check whether any commit introduces new CLI flags, options, agents, or user-visible behavior that isn't reflected in `README.md`. If gaps are found, list them and ask the user to update `README.md` before continuing:
 
@@ -148,7 +150,7 @@ pnpm build
 
 Stop if this fails.
 
-## Step 7: Commit and push the release
+## Step 7: Commit the release and create a branch
 
 In jj, file changes are automatically snapshotted in the working-copy commit. Describe it and move to a new empty commit:
 
@@ -157,30 +159,66 @@ jj describe -m "release v<version>"
 jj new
 ```
 
-Advance the main bookmark to the release commit, then push:
+Create a release branch pointing to the release commit (do NOT move main):
 
 ```bash
-jj bookmark set main -r @-
-jj git push --bookmark main
+jj bookmark set release/v<version> -r @-
 ```
 
-## Step 8: Create and push the tag (triggers npm publish)
+## Step 8: Push branch and open release PR
+
+Push the release branch to the fork:
+
+```bash
+jj git push --bookmark release/v<version> --remote fork
+```
+
+If the fork remote doesn't exist, create it first:
+
+```bash
+git remote add fork https://github.com/BoldBlackBot/harness.git
+jj git push --bookmark release/v<version> --remote fork
+```
+
+Open the PR:
+
+```bash
+gh pr create \
+  --repo boldblackai/harness \
+  --head BoldBlackBot:release/v<version> \
+  --base main \
+  --title "release v<version>" \
+  --body "Release v<version>.
+
+See CHANGELOG.md for details.
+
+Merge to trigger the automated npm publish (OIDC trusted publishing)."
+```
+
+## Step 9: Wait for maintainer to merge the PR
+
+**STOP HERE.** The skill cannot proceed until the PR is merged. Tell the user:
+
+> "Release PR #N is up: <url>. Review and merge it, then tell me to continue."
+
+Do not proceed to Step 10 until the user confirms the PR has been merged.
+
+## Step 10: Tag the merge commit (triggers npm publish)
+
+After the user confirms the PR is merged, fetch the latest main and tag the merge commit:
+
+```bash
+git fetch origin main
+MERGE_SHA=$(git rev-parse origin/main)
+git tag v<version> $MERGE_SHA
+git push origin v<version>
+```
 
 The tag push triggers `.github/workflows/publish.yml`, which publishes to npm via OIDC trusted publishing — automatically, no manual intervention needed.
 
-Create the tag locally pointing to the release commit (one behind `@`, the current empty working copy):
+> **Important:** Tag `origin/main` (the merge commit), not the branch commit. The PR was squash- or rebase-merged, so the SHA on main is different from the branch SHA.
 
-```bash
-jj tag set v<version> -r @-
-```
-
-Push it to the remote (jj doesn't support pushing tags directly; use git):
-
-```bash
-git push --tags
-```
-
-## Step 9: Verify npm publish succeeded
+## Step 11: Verify npm publish succeeded
 
 The tag push triggers `publish.yml`. Poll until it completes:
 
@@ -202,21 +240,22 @@ npm view @boldblackai/harness@<version> dist --json
 
 Confirm the output includes an `attestations` field (not just `signatures`). If `attestations` is missing, the publish did not generate provenance — investigate before continuing.
 
-Do not proceed to Step 10 until the npm package is confirmed published with provenance.
+Do not proceed to Step 12 until the npm package is confirmed published with provenance.
 
-## Step 10: Create GitHub release
+## Step 12: Create GitHub release
 
 Extract the changelog section for this version — everything from `## [<version>]` down to (but not including) the next `## [` entry.
 
 ```bash
 gh release create v<version> \
+  --repo boldblackai/harness \
   --title "v<version>" \
   --notes "<changelog-entry>"
 ```
 
 This triggers the Docker image build workflow (`docker.yml`).
 
-## Step 11: Post-flight — verify Docker CI succeeded
+## Step 13: Post-flight — verify Docker CI succeeded
 
 The GitHub release triggers `docker.yml`. Poll until the release-triggered workflow run completes:
 
@@ -251,6 +290,7 @@ Tell the user:
 
 - Version released
 - The CHANGELOG entry added
+- Release PR URL (merged)
 - npm publish status (workflow green, provenance attestations confirmed)
 - GitHub release URL (from `gh release create` stdout)
 - Docker CI status (all jobs green)

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -5,7 +5,11 @@ description: Automate releasing the harness npm package. Use this skill whenever
 
 # Release Skill for `harness`
 
-Automates the full release pipeline: pre-flight checks → version bump → CHANGELOG → build → publish → tag → GitHub release.
+Automates the full release pipeline: pre-flight checks → version bump → CHANGELOG → build → commit/push main → tag (triggers npm publish via OIDC trusted publishing) → verify npm → GitHub release → verify CI.
+
+> **npm publishing is fully automated via [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC).** Pushing a `v*` tag triggers `.github/workflows/publish.yml`, which authenticates to npm via a short-lived OIDC token — no long-lived npm token, no manual `npm publish`, no OTP. Provenance attestations are generated automatically. The trust boundary is "can push to main" = "can release."
+>
+> **Prerequisite (one-time, manual on npmjs.com):** Configure the trusted publisher for `@boldblackai/harness` under Settings → Trusted Publisher → GitHub Actions: org=`boldblackai`, repo=`harness`, workflow filename=`publish.yml`. Then under Settings → Publishing access, select "Require two-factor authentication and disallow tokens" (recommended) — OIDC publishes are unaffected by this setting.
 
 ## Step 1: Pre-flight checks (abort on failure)
 
@@ -20,7 +24,7 @@ If they differ, there are unpushed commits on `main`. Inform the user:
 
 > "Aborting: local main is ahead of main@origin. Push your commits first with `jj git push`."
 
-**Clean working state** — Run `jj status`. If there are uncommitted changes beyond what you're about to create (package.json + CHANGELOG.md), warn the user and ask whether to proceed.
+**Clean working state** — Run `jj status`. If there are uncommitted changes beyond what you're about to create (`package.json` + `CHANGELOG.md`), warn the user and ask whether to proceed.
 
 **README is up to date** — Read `README.md` and the commits since the last tag (collected in Step 3). Check whether any commit introduces new CLI flags, options, agents, or user-visible behavior that isn't reflected in `README.md`. If gaps are found, list them and ask the user to update `README.md` before continuing:
 
@@ -160,15 +164,9 @@ jj bookmark set main -r @-
 jj git push --bookmark main
 ```
 
-## Step 8: Publish to npm
+## Step 8: Create and push the tag (triggers npm publish)
 
-npm publish requires an OTP and cannot be automated. Tell the user:
-
-> "Please run `npm publish` (with `--otp=<code>` if prompted for 2FA). Let me know when it succeeds and I'll continue."
-
-Wait for the user to confirm success before proceeding to Step 9.
-
-## Step 9: Create and push the tag
+The tag push triggers `.github/workflows/publish.yml`, which publishes to npm via OIDC trusted publishing — automatically, no manual intervention needed.
 
 Create the tag locally pointing to the release commit (one behind `@`, the current empty working copy):
 
@@ -182,6 +180,30 @@ Push it to the remote (jj doesn't support pushing tags directly; use git):
 git push --tags
 ```
 
+## Step 9: Verify npm publish succeeded
+
+The tag push triggers `publish.yml`. Poll until it completes:
+
+```bash
+gh run list --repo boldblackai/harness --workflow publish.yml --limit 1
+```
+
+Use the run ID to watch for completion:
+
+```bash
+gh run watch <run-id> --repo boldblackai/harness
+```
+
+Once the workflow succeeds, verify the package landed on npm **with provenance attestations**:
+
+```bash
+npm view @boldblackai/harness@<version> dist --json
+```
+
+Confirm the output includes an `attestations` field (not just `signatures`). If `attestations` is missing, the publish did not generate provenance — investigate before continuing.
+
+Do not proceed to Step 10 until the npm package is confirmed published with provenance.
+
 ## Step 10: Create GitHub release
 
 Extract the changelog section for this version — everything from `## [<version>]` down to (but not including) the next `## [` entry.
@@ -192,18 +214,20 @@ gh release create v<version> \
   --notes "<changelog-entry>"
 ```
 
-## Step 11: Post-flight — verify CI succeeded
+This triggers the Docker image build workflow (`docker.yml`).
 
-After creating the GitHub release, poll until the release-triggered workflow run completes:
+## Step 11: Post-flight — verify Docker CI succeeded
+
+The GitHub release triggers `docker.yml`. Poll until the release-triggered workflow run completes:
 
 ```bash
-gh run list --repo <owner>/<repo> --event release --limit 1
+gh run list --repo boldblackai/harness --event release --limit 1
 ```
 
 Use the run ID to watch for completion:
 
 ```bash
-gh run view <run-id> --repo <owner>/<repo>
+gh run view <run-id> --repo boldblackai/harness
 ```
 
 Check that **all jobs** show `✓` (success). Pay particular attention to:
@@ -214,7 +238,7 @@ Check that **all jobs** show `✓` (success). Pay particular attention to:
 If any job failed, run:
 
 ```bash
-gh run rerun <run-id> --failed --repo <owner>/<repo>
+gh run rerun <run-id> --failed --repo boldblackai/harness
 ```
 
 Then wait for it to complete and verify again before reporting success.
@@ -227,5 +251,6 @@ Tell the user:
 
 - Version released
 - The CHANGELOG entry added
+- npm publish status (workflow green, provenance attestations confirmed)
 - GitHub release URL (from `gh release create` stdout)
-- CI status (all jobs green)
+- Docker CI status (all jobs green)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
+      - run: npm publish


### PR DESCRIPTION
## What

Replaces manual `npm publish` (with OTP) with **automated trusted publishing** via GitHub Actions OIDC. Pushing a `v*` tag now triggers `publish.yml`, which authenticates to npm via a short-lived OIDC token — no long-lived npm token, no OTP, provenance auto-generated.

This directly fixes the [Socket.dev](https://socket.dev/npm/package/%40boldblackai%2Fharness) supply chain score gap: the npm package previously shipped with no provenance attestations (unlike the Docker images, which already had cosign + SLSA).

## Changes

**`.github/workflows/publish.yml`** (new) — Tag-triggered (`v*`), OIDC trusted publishing:
- `permissions: id-token: write` (required for OIDC)
- No `NODE_AUTH_TOKEN` secret — OIDC handles auth
- Provenance attestations generated automatically (no `--provenance` flag needed)
- Action SHAs pinned to match existing workflows

**`.agents/skills/release/SKILL.md`** (updated) — Release flow restructured:

| | Old flow | New flow |
|---|---|---|
| Step 8 | Manual: `npm publish --otp=<code>` | Tag push → `publish.yml` auto-publishes via OIDC |
| Step 9 | Create + push tag | Verify npm publish succeeded (CI green + `dist.attestations` present) |
| Step 10 | Create GH release | Create GH release (triggers `docker.yml`) |
| Step 11 | Verify Docker CI | Verify Docker CI |

The key inversion: **the tag, not the human, triggers the publish.** The agent never touches npm credentials.

## Prerequisite (one-time, manual on npmjs.com)

These must be done by a maintainer in the browser — they're account-scoped, not in-repo:

1. **Settings → Trusted Publisher → GitHub Actions:**
   - Organization: `boldblackai`
   - Repository: `harness`
   - Workflow filename: `publish.yml`
2. **Settings → Publishing access →** "Require two-factor authentication and disallow tokens" (recommended)

After that, the next release via the skill will publish automatically with provenance.

## Trust model

Per discussion: "pushing to main → can release" is the accepted boundary. No GitHub environment approval gate, no npm staged publishing. Anyone who can push to main is trusted to release. Provenance + OIDC eliminate the token as an attack vector; branch protection (PR + code owner review) is the access control.

Co-authored-by: Julio <capotej@users.noreply.github.com>